### PR TITLE
DD-900. Separate import and migration areas

### DIFF
--- a/src/main/assembly/dist/bin/ingest-flow
+++ b/src/main/assembly/dist/bin/ingest-flow
@@ -11,7 +11,7 @@ service_baseurl = 'http://localhost:20300'
 
 file_writeable_to_group = lambda f: os.stat(f).st_mode & stat.S_IWGRP > 0
 
-def start_import(path, continue_previous, migration):
+def start_import(path, continue_previous, is_migration):
     if not has_dirtree_pred(path, file_writeable_to_group):
         chmod_command = "chmod -R g+w %s" % path
         print("Some files in the import batch do not give the owner group write permissions. Executing '%s' to fix it" % chmod_command)
@@ -20,10 +20,9 @@ def start_import(path, continue_previous, migration):
             print("Could not give owner group write permissions. Possibly your account is not the owner user of the files.")
             return
     print("Sending start import request to server...")
-    r = requests.post('%s/imports/:start' % service_baseurl, json={
+    r = requests.post('%s/%s/:start' % (service_baseurl, "migrations" if is_migration else "imports"), json={
         'batch': os.path.abspath(path),
-        'continue': continue_previous,
-        'migration': migration
+        'continue': continue_previous
     })
     print('Server responded: %s' % r.text)
 
@@ -47,7 +46,6 @@ parser = argparse.ArgumentParser(add_help=True)
 subparsers = parser.add_subparsers(dest='command')
 parser_import = subparsers.add_parser('start-import',
                                       help='start import of a batch of deposits')
-
 parser_import.add_argument('batch',
                            metavar='<batch-directory>',
                            help='path to batch of deposits to import; the directory must be located inside the import area')
@@ -55,11 +53,17 @@ parser_import.add_argument('-c', '--continue',
                            action='store_true',
                            dest='continue_previous',
                            help='continue previously stopped batch (i.e. allow output directory to be non-empty)')
-parser_import.add_argument('-m', '--migration',
+
+parser_migration = subparsers.add_parser('start-migration',
+                                      help='start migration of a batch of deposits')
+parser_migration.add_argument('batch',
+                           metavar='<batch-directory>',
+                           help='path to batch of deposits to migration; the directory must be located inside the migration area')
+parser_migration.add_argument('-c', '--continue',
                            action='store_true',
-                           dest='migration',
-                           default=True,
-                           help='import as migrated datasets (default = True)')
+                           dest='continue_previous',
+                           help='continue previously stopped batch (i.e. allow output directory to be non-empty)')
+
 
 parser_events = subparsers.add_parser('list-events',
                                       help='print events per deposit')
@@ -85,8 +89,10 @@ parser_status.add_argument('-d', '--deposit',
 
 args = parser.parse_args()
 
+if args.command == 'start-migration':
+    start_import(args.batch, args.continue_previous, True)
 if args.command == 'start-import':
-    start_import(args.batch, args.continue_previous, args.migration)
+    start_import(args.batch, args.continue_previous, False)
 elif args.command == 'list-events':
     params = {}
     if args.source is not None:

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -13,12 +13,16 @@ server:
 
 ingestFlow:
   import:
+    inbox: /var/opt/dans.knaw.nl/tmp/import/inbox
+    outbox: /var/opt/dans.knaw.nl/tmp/import/outbox
+
+  migration:
     inbox: /var/opt/dans.knaw.nl/tmp/migration/deposits
     outbox: /var/opt/dans.knaw.nl/tmp/migration/out
 
   autoIngest:
-    inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/in
-    outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/out
+    inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
+    outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox
 
   #
   # Filtering. Files with a path matching the pattern will not be added to the dataset. Renaming/moving files is not affected.
@@ -31,6 +35,7 @@ ingestFlow:
   deduplicate: true
   zipWrappingTempDir: /var/opt/dans.knaw.nl/tmp/zip-wrapping
   mappingDefsDir: /etc/opt/dans.knaw.nl/dd-ingest-flow
+  retryStalledAfter: 1 minute
   taskQueue:
     nameFormat: "ingest-worker-%d"
     maxQueueSize: 5000

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -35,7 +35,6 @@ ingestFlow:
   deduplicate: true
   zipWrappingTempDir: /var/opt/dans.knaw.nl/tmp/zip-wrapping
   mappingDefsDir: /etc/opt/dans.knaw.nl/dd-ingest-flow
-  retryStalledAfter: 1 minute
   taskQueue:
     nameFormat: "ingest-worker-%d"
     maxQueueSize: 5000

--- a/src/main/assembly/dist/install/dd-ingest-flow.service
+++ b/src/main/assembly/dist/install/dd-ingest-flow.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Dd Ingest Flow Service
+After=payara.service easy-validate-dans-bag.service
 
 [Service]
 ExecStart=/opt/dans.knaw.nl/dd-ingest-flow/bin/dd-ingest-flow server /etc/opt/dans.knaw.nl/dd-ingest-flow/config.yml

--- a/src/main/java/nl/knaw/dans/ingest/api/StartImport.java
+++ b/src/main/java/nl/knaw/dans/ingest/api/StartImport.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 public class StartImport {
     private Path batch;
     private boolean continuePrevious = false;
-    private boolean isMigration = false;
 
     public Path getBatch() {
         return batch;
@@ -40,14 +39,6 @@ public class StartImport {
     @JsonProperty("continue")
     public void setContinue(boolean continuePrevious) {
         this.continuePrevious = continuePrevious;
-    }
-
-    public boolean isMigration() {
-        return isMigration;
-    }
-
-    public void setMigration(boolean migration) {
-        isMigration = migration;
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class AbstractInbox {
-    private static final Logger log = LoggerFactory.getLogger(AbstractInbox.class);
+public class AbstractIngestArea {
+    private static final Logger log = LoggerFactory.getLogger(AbstractIngestArea.class);
     protected final Path inboxDir;
     protected final Path outboxDir;
     protected final DepositIngestTaskFactoryWrapper taskFactory;
     protected final TaskEventService taskEventService;
     protected final EnqueuingService enqueuingService;
 
-    public AbstractInbox(Path inboxDir, Path outboxDir,
+    public AbstractIngestArea(Path inboxDir, Path outboxDir,
         DepositIngestTaskFactoryWrapper taskFactory, TaskEventService taskEventService, EnqueuingService enqueuingService) {
         this.inboxDir = inboxDir.toAbsolutePath();
         this.outboxDir = outboxDir.toAbsolutePath();
@@ -66,7 +66,7 @@ public class AbstractInbox {
             Files.createDirectories(failedDir);
             Files.createDirectories(rejectedDir);
 
-            if (!allowNonEmpty && (AbstractInbox.nonEmpty(processedDir) || AbstractInbox.nonEmpty(failedDir) || AbstractInbox.nonEmpty(rejectedDir))) {
+            if (!allowNonEmpty && (AbstractIngestArea.nonEmpty(processedDir) || AbstractIngestArea.nonEmpty(failedDir) || AbstractIngestArea.nonEmpty(rejectedDir))) {
                 throw new IllegalArgumentException("outbox is not empty; start with empty outbox at " + outbox + ", or use the 'continue' option");
             }
         }

--- a/src/main/java/nl/knaw/dans/ingest/core/AutoIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AutoIngestArea.java
@@ -23,10 +23,10 @@ import nl.knaw.dans.ingest.core.service.TaskEventService;
 
 import java.nio.file.Path;
 
-public class AutoIngestInbox extends AbstractInbox implements Managed {
+public class AutoIngestArea extends AbstractIngestArea implements Managed {
     private UnboundedTargetedTaskSource taskSource;
 
-    public AutoIngestInbox(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory,
+    public AutoIngestArea(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory,
         TaskEventService taskEventService, EnqueuingService enqueuingService) {
         super(inboxDir, outboxDir, taskFactory, taskEventService, enqueuingService);
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -29,12 +29,12 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ImportInbox extends AbstractInbox {
-    private static final Logger log = LoggerFactory.getLogger(ImportInbox.class);
+public class ImportArea extends AbstractIngestArea {
+    private static final Logger log = LoggerFactory.getLogger(ImportArea.class);
     private final DepositIngestTaskFactoryWrapper migrationTaskFactory;
     private final Map<String, TargetedTaskSource<DepositImportTaskWrapper>> batches = new HashMap<>();
 
-    public ImportInbox(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory, DepositIngestTaskFactoryWrapper migrationTaskFactory,
+    public ImportArea(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory, DepositIngestTaskFactoryWrapper migrationTaskFactory,
         TaskEventService taskEventService, EnqueuingService enqueuingService) {
         super(inboxDir, outboxDir, taskFactory, taskEventService, enqueuingService);
         this.migrationTaskFactory = migrationTaskFactory;

--- a/src/main/java/nl/knaw/dans/ingest/core/config/IngestAreaConfig.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/config/IngestAreaConfig.java
@@ -17,7 +17,7 @@ package nl.knaw.dans.ingest.core.config;
 
 import java.nio.file.Path;
 
-public class InOutConfig {
+public class IngestAreaConfig {
     private Path inbox;
     private Path outbox;
 

--- a/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
@@ -26,11 +26,16 @@ public class IngestFlowConfig {
     @NotNull
     @Valid
     @JsonProperty("import")
-    private InOutConfig importConfig;
+    private IngestAreaConfig importConfig;
 
     @NotNull
     @Valid
-    private InOutConfig autoIngest;
+    private IngestAreaConfig migration;
+
+
+    @NotNull
+    @Valid
+    private IngestAreaConfig autoIngest;
 
     @NotNull
     @Valid
@@ -55,19 +60,27 @@ public class IngestFlowConfig {
     @Valid
     private ExecutorServiceFactory taskQueue;
 
-    public InOutConfig getImportConfig() {
+    public IngestAreaConfig getImportConfig() {
         return importConfig;
     }
 
-    public void setImportConfig(InOutConfig importConfig) {
+    public void setImportConfig(IngestAreaConfig importConfig) {
         this.importConfig = importConfig;
     }
 
-    public InOutConfig getAutoIngest() {
+    public IngestAreaConfig getMigration() {
+        return migration;
+    }
+
+    public void setMigration(IngestAreaConfig migration) {
+        this.migration = migration;
+    }
+
+    public IngestAreaConfig getAutoIngest() {
         return autoIngest;
     }
 
-    public void setAutoIngest(InOutConfig autoIngest) {
+    public void setAutoIngest(IngestAreaConfig autoIngest) {
         this.autoIngest = autoIngest;
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -29,15 +29,15 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/imports")
+@Path("/migrations")
 @Produces(MediaType.APPLICATION_JSON)
-public class ImportsResource {
-    private static final Logger log = LoggerFactory.getLogger(ImportsResource.class);
+public class MigrationsResource {
+    private static final Logger log = LoggerFactory.getLogger(MigrationsResource.class);
 
-    private final ImportArea importArea;
+    private final ImportArea migrationArea;
 
-    public ImportsResource(ImportArea importArea) {
-        this.importArea = importArea;
+    public MigrationsResource(ImportArea migrationArea) {
+        this.migrationArea = migrationArea;
     }
 
     @POST
@@ -47,14 +47,14 @@ public class ImportsResource {
         log.trace("Received command = {}", start);
         String batchName;
         try {
-            batchName = importArea.startBatch(start.getBatch(), start.isContinue(), false);
+            batchName = migrationArea.startBatch(start.getBatch(), start.isContinue(), true);
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());
         }
         return Response.accepted(
                 new ResponseMessage(Response.Status.ACCEPTED.getStatusCode(),
-                    String.format("import request was received (batch = %s, continue = %s", batchName, start.isContinue())))
+                    String.format("migration request was received (batch = %s, continue = %s", batchName, start.isContinue())))
             .build();
     }
 }


### PR DESCRIPTION
Fixes DD-900

# Description of changes
* Adds a new configuration section to configure the migration area.
* Renames "inboxes" into "ingest areas" to make it a bit more logical, because these "ingest areas" contain an inbox and outbox.
* Adds a `start-migration` subcommand and removes the `--migration` flag from `start-import`.

# Related PRs

* https://github.com/DANS-KNAW/dd-dtap/pull/213

# Notify

@DANS-KNAW/dataversedans
