### PR TITLE
DD-901. use Has Personal Info = unknown if not specified by client in auto-ingest

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -36,7 +36,7 @@ import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
-import scala.xml.Elem
+import scala.xml.{ Elem, Node }
 
 /**
  * Checks one deposit and then ingests it into Dataverse.
@@ -151,8 +151,16 @@ case class DepositIngestTask(deposit: Deposit,
       datasetContacts <- getDatasetContacts
       ddm <- deposit.tryDdm
       optAgreements <- deposit.tryOptAgreementsXml
+      _ <- checkPersonalDataPresent(optAgreements)
       dataverseDataset <- datasetMetadataMapper.toDataverseDataset(ddm, optAgreements, optDateOfDeposit, datasetContacts, deposit.vaultMetadata)
     } yield dataverseDataset
+  }
+
+  /*
+   * See DD-901. For non-migration imports we will accept missing agreement.xml for now
+   */
+  protected def checkPersonalDataPresent(optAgreements: Option[Node]): Try[Unit] = {
+    Success(())
   }
 
   protected def getDateOfDeposit: Try[Option[String]] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -81,6 +81,11 @@ class DepositMigrationTask(deposit: Deposit,
     new DatasetCreator(deposit, optFileExclusionPattern, zipFileHandler, depositorRole, isMigration = true, dataverseDataset, variantToLicense, supportedLicenses, instance, migrationInfo)
   }
 
+  override protected def checkPersonalDataPresent(optAgreements: Option[Node]): Try[Unit] = {
+    if (optAgreements.isEmpty) Failure(RejectedDepositException(deposit, "Migration deposit MUST have an agreements.xml"))
+    else Success(())
+  }
+
   override protected def getDateOfDeposit: Try[Option[String]] = {
     for {
       optAmd <- deposit.tryOptAmd


### PR DESCRIPTION
Fixes DD-901

# Description of changes
* For non-migration deposits fill in `Unknown` if agreements.xml is not found.
* For migration deposits reject the deposit if agreements.xml is not found.

# How to test
* Test a SWORD deposit and a migration deposit without agreements.xml


# Notify

@DANS-KNAW/dataversedans
