### PR TITLE
DD-906: Character encoding output ingest-flow list-events incorrect

### DIFF
--- a/src/main/assembly/dist/bin/ingest-flow
+++ b/src/main/assembly/dist/bin/ingest-flow
@@ -40,6 +40,7 @@ def has_dirtree_pred(dir, pred):
 
 def list_events(params):
     r = requests.get('%s/events' % service_baseurl, headers={'Accept': 'text/csv'}, params=params)
+    r.encoding = r.apparent_encoding
     print(r.text)
 
 parser = argparse.ArgumentParser(add_help=True)


### PR DESCRIPTION
Fixes DD-906

# Description of changes
`list_events` result encoded to `utf-8`

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
