### PR TITLE
DD-803 Add TechnicalInfo as description

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -83,7 +83,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       addCompoundFieldMultipleValues(citationFields, DESCRIPTION, ddm \ "profile" \ "description", Description toDescriptionValueObject)
       addCompoundFieldMultipleValues(citationFields, DESCRIPTION, if (alternativeTitles.isEmpty) NodeSeq.Empty
                                                                   else alternativeTitles.tail, Description toDescriptionValueObject)
-      val otherDescriptions = (ddm \ "dcmiMetadata" \ "description") ++
+      val otherDescriptions =
         (ddm \ "dcmiMetadata" \ "date") ++
         (ddm \ "dcmiMetadata" \ "dateAccepted") ++
         (ddm \ "dcmiMetadata" \ "dateCopyrighted ") ++
@@ -92,6 +92,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
         (ddm \ "dcmiMetadata" \ "valid") ++
         (ddm \ "dcmiMetadata" \ "coverage")
       addCompoundFieldMultipleValues(citationFields, DESCRIPTION, otherDescriptions, Description toPrefixedDescription)
+      addCompoundFieldMultipleValues(citationFields, DESCRIPTION, (ddm \ "dcmiMetadata" \ "description").filter(Description isTechnicalInfo), Description toDescriptionValueObject)
 
       checkRequiredField(SUBJECT, ddm \ "profile" \ "audience")
       addCvFieldMultipleValues(citationFields, SUBJECT, ddm \ "profile" \ "audience", Audience toCitationBlockSubject)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
@@ -54,4 +54,9 @@ object Description extends BlockCitation {
       .map(_.replaceAll(newline, "<br>"))
       .mkString
   }
+
+  def isTechnicalInfo(node: Node): Boolean = {
+    hasAttribute(node, "descriptionType", "TechnicalInfo")
+  }
+
 }


### PR DESCRIPTION
Fixes DD-803

# Description of changes
* `dcmiMetadata / description` is now added as a description if it has an attribute `descriptionType = TechnicalInfo`.
* Other `dcmiMetadata / description` elements are now ignored, as per specs.


# Notify

@DANS-KNAW/dataversedans
