### PR TITLE
DD-859. Sort values of multi-value controlledVocabulary field

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -252,7 +252,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
   private def addCvFieldMultipleValues(metadataBlockFields: mutable.HashMap[String, AbstractFieldBuilder], name: String, sourceNodes: NodeSeq, nodeTransformer: Node => Option[String]): Unit = {
     val values = sourceNodes.map(nodeTransformer).filter(_.isDefined).map(_.get).toList
     metadataBlockFields.getOrElseUpdate(name, new CvFieldBuilder(name)) match {
-      case cfb: CvFieldBuilder => values.filterNot(StringUtils.isBlank).foreach(cfb.addValue)
+      case cfb: CvFieldBuilder => values.filterNot(StringUtils.isBlank).sorted.foreach(cfb.addValue)
       case _ => throw new IllegalArgumentException("Trying to add non-controlled-vocabulary value(s) to controlled vocabulary field")
     }
   }


### PR DESCRIPTION
Fixes DD-859

# Description of changes
Sort values of multi-value controlledVocabulary field

# How to test
Import a deposit with multiple subjects or languages, given in non-alphabetical order.


# Notify

@DANS-KNAW/dataversedans
