### PR TITLE
DD-897: dd-ingest-flow: implement health checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>dropwizard-hibernate</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.modules</groupId>
+            <artifactId>dropwizard-health</artifactId>
+            <version>1.7.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
         </dependency>
@@ -89,6 +94,11 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -1,3 +1,18 @@
+health:
+  delayedShutdownHandlerEnabled: false
+  initialOverallState: false
+  healthChecks:
+    - name: Dataverse
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
+    - name: DansBagValidator
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
+
 #
 # Http-interfaces
 #

--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowConfiguration.java
@@ -16,11 +16,16 @@
 
 package nl.knaw.dans.ingest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.health.conf.HealthConfiguration;
 import nl.knaw.dans.ingest.core.config.DataverseConfigScala;
 import nl.knaw.dans.ingest.core.config.HttpServiceConfig;
 import nl.knaw.dans.ingest.core.config.IngestFlowConfig;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 public class DdIngestFlowConfiguration extends Configuration {
 
@@ -29,6 +34,19 @@ public class DdIngestFlowConfiguration extends Configuration {
     private HttpServiceConfig validateDansBag;
     private HttpServiceConfig managePrestaging;
     private DataSourceFactory taskEventDatabase;
+
+    @Valid
+    @NotNull
+    @JsonProperty("health")
+    private HealthConfiguration healthConfiguration = new HealthConfiguration();
+
+    public HealthConfiguration getHealthConfiguration() {
+        return healthConfiguration;
+    }
+
+    public void setHealthConfiguration(final HealthConfiguration healthConfiguration) {
+        this.healthConfiguration = healthConfiguration;
+    }
 
     public IngestFlowConfig getIngestFlow() {
         return ingestFlow;

--- a/src/main/java/nl/knaw/dans/ingest/core/health/DansBagValidatorHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/health/DansBagValidatorHealthCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DansBagValidatorHealthCheck extends HealthCheck {
+    private static final Logger log = LoggerFactory.getLogger(DansBagValidatorHealthCheck.class);
+
+    private final DansBagValidator dansBagValidatorInstance;
+
+    public DansBagValidatorHealthCheck(DansBagValidator dansBagValidatorInstance) {
+        this.dansBagValidatorInstance = dansBagValidatorInstance;
+    }
+
+    @Override
+    protected Result check() {
+        log.debug("Checking that Dans Bag Validator is available");
+
+        if (dansBagValidatorInstance.checkConnection().isSuccess()) {
+            return Result.healthy();
+        }
+        else {
+            return Result.unhealthy("Dans Bag Validator is not available");
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/health/DataverseHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/health/DataverseHealthCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import nl.knaw.dans.lib.dataverse.DataverseInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataverseHealthCheck extends HealthCheck {
+    private static final Logger log = LoggerFactory.getLogger(DataverseHealthCheck.class);
+
+    private final DataverseInstance dataverseInstance;
+
+    public DataverseHealthCheck(DataverseInstance dataverseInstance) {
+        this.dataverseInstance = dataverseInstance;
+    }
+
+    @Override
+    protected Result check() {
+        log.debug("Checking that Dataverse is available");
+
+        if (dataverseInstance.checkConnection().isSuccess()) {
+            return Result.healthy();
+        }
+        else {
+            return Result.unhealthy("Dataverse is not available");
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/legacy/DepositIngestTaskFactoryWrapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/legacy/DepositIngestTaskFactoryWrapper.java
@@ -31,6 +31,8 @@ import nl.knaw.dans.lib.dataverse.DataverseInstanceConfig;
 import scala.Option;
 import scala.collection.immutable.List;
 import scala.collection.immutable.Map;
+import scala.runtime.BoxedUnit;
+import scala.util.Try;
 import scala.xml.Elem;
 
 import java.net.URI;
@@ -42,6 +44,8 @@ import java.util.regex.Pattern;
  */
 public class DepositIngestTaskFactoryWrapper {
     private final DepositIngestTaskFactory factory;
+    private final DataverseInstance dataverseInstance;
+    private final DansBagValidator validator;
 
     public DepositIngestTaskFactoryWrapper(
         boolean isMigration,
@@ -50,7 +54,7 @@ public class DepositIngestTaskFactoryWrapper {
         HttpServiceConfig migrationInfoConfig,
         HttpServiceConfig validationDansBagConfig) {
 
-        final DataverseInstance dataverseInstance = new DataverseInstance(new DataverseInstanceConfig(
+        dataverseInstance = new DataverseInstance(new DataverseInstanceConfig(
             DepositIngestTaskFactory.appendSlash(dataverseConfigScala.getHttp().getBaseUrl()),
             dataverseConfigScala.getApi().getApiKey(),
             Option.apply(dataverseConfigScala.getApi().getUnblockKey()),
@@ -60,7 +64,7 @@ public class DepositIngestTaskFactoryWrapper {
             dataverseConfigScala.getApi().getAwaitUnlockMaxRetries(),
             dataverseConfigScala.getApi().getAwaitUnlockWaitTimeMs()));
 
-        final DansBagValidator validator = new DansBagValidator(
+        validator = new DansBagValidator(
             DepositIngestTaskFactory.appendSlash(validationDansBagConfig.getBaseUrl()),
             validationDansBagConfig.getConnectionTimeoutMs(),
             validationDansBagConfig.getReadTimeoutMs());
@@ -116,5 +120,13 @@ public class DepositIngestTaskFactoryWrapper {
 
     public DepositImportTaskWrapper createIngestTask(Path depositDir, Path outboxDir, EventWriter eventWriter) {
         return new DepositImportTaskWrapper(factory.createDepositIngestTask(new Deposit(File.apply(depositDir)), File.apply(outboxDir)), eventWriter);
+    }
+
+    public DataverseInstance getDataverseInstance() {
+        return dataverseInstance;
+    }
+
+    public DansBagValidator getDansBagValidatorInstance() {
+        return validator;
     }
 }

--- a/src/test/java/nl/knaw/dans/ingest/core/health/BagValidatorHealthCheck.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/health/BagValidatorHealthCheck.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.health;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator;
+import nl.knaw.dans.ingest.core.legacy.DepositIngestTaskFactoryWrapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+
+class BagValidatorHealthCheck {
+
+    @Test
+    void checkDansBagValidatorAvailable() {
+        DepositIngestTaskFactoryWrapper depositIngestTaskFactoryWrapper = Mockito.mock(DepositIngestTaskFactoryWrapper.class);
+        DansBagValidator dansBagValidator = Mockito.mock(DansBagValidator.class, RETURNS_DEEP_STUBS);
+        Mockito.when(dansBagValidator.checkConnection().isSuccess()).thenReturn(true);
+        Mockito.when(depositIngestTaskFactoryWrapper.getDansBagValidatorInstance()).thenReturn(dansBagValidator);
+        Result result = new DansBagValidatorHealthCheck(depositIngestTaskFactoryWrapper.getDansBagValidatorInstance()).check();
+        assertTrue(result.isHealthy());
+    }
+
+    @Test
+    void checkDansBagValidatorNotAvailable() {
+        DepositIngestTaskFactoryWrapper depositIngestTaskFactoryWrapper = Mockito.mock(DepositIngestTaskFactoryWrapper.class);
+        DansBagValidator dansBagValidator = Mockito.mock(DansBagValidator.class, RETURNS_DEEP_STUBS);
+        Mockito.when(dansBagValidator.checkConnection().isSuccess()).thenReturn(false);
+        Mockito.when(depositIngestTaskFactoryWrapper.getDansBagValidatorInstance()).thenReturn(dansBagValidator);
+        Result result = new DansBagValidatorHealthCheck(depositIngestTaskFactoryWrapper.getDansBagValidatorInstance()).check();
+        assertFalse(result.isHealthy());
+    }
+}

--- a/src/test/java/nl/knaw/dans/ingest/core/health/DataverseInstanceHealthCheck.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/health/DataverseInstanceHealthCheck.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.health;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import nl.knaw.dans.ingest.core.legacy.DepositIngestTaskFactoryWrapper;
+import nl.knaw.dans.lib.dataverse.DataverseInstance;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+
+class DataverseInstanceHealthCheck {
+
+    @Test
+    void checkDataverseAvailable() {
+        DepositIngestTaskFactoryWrapper depositIngestTaskFactoryWrapper = Mockito.mock(DepositIngestTaskFactoryWrapper.class);
+        DataverseInstance dataverseInstance = Mockito.mock(DataverseInstance.class, RETURNS_DEEP_STUBS);
+        Mockito.when(dataverseInstance.checkConnection().isSuccess()).thenReturn(true);
+        Mockito.when(depositIngestTaskFactoryWrapper.getDataverseInstance()).thenReturn(dataverseInstance);
+        Result result = new DataverseHealthCheck(depositIngestTaskFactoryWrapper.getDataverseInstance()).check();
+        assertTrue(result.isHealthy());
+    }
+
+    @Test
+    void checkDataverseNotAvailable() {
+        DepositIngestTaskFactoryWrapper depositIngestTaskFactoryWrapper = Mockito.mock(DepositIngestTaskFactoryWrapper.class);
+        DataverseInstance dataverseInstance = Mockito.mock(DataverseInstance.class, RETURNS_DEEP_STUBS);
+        Mockito.when(dataverseInstance.checkConnection().isSuccess()).thenReturn(false);
+        Mockito.when(depositIngestTaskFactoryWrapper.getDataverseInstance()).thenReturn(dataverseInstance);
+        Result result = new DataverseHealthCheck(depositIngestTaskFactoryWrapper.getDataverseInstance()).check();
+        assertFalse(result.isHealthy());
+    }
+}


### PR DESCRIPTION
Fixes DD-897

# Description of changes
Added `health checks` for `Dataverse` and `easy-validate-dans-bag `services
# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
