### PR TITLE
DD-963 Scala case match error when processing contributorDetails author instead of organization

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -77,6 +77,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
           addCompoundFieldMultipleValues(citationFields, AUTHOR, node \ "organization", DcxDaiOrganization toAuthorValueObject)
         case node if node.label == "creator" =>
           addCompoundFieldMultipleValues(citationFields, AUTHOR, node, Creator toAuthorValueObject)
+        case _ => // Do nothing
       }
 
       addCompoundFieldMultipleValues(citationFields, DATASET_CONTACT, contactData)
@@ -111,12 +112,14 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
           (node \ "author").filterNot(DcxDaiAuthor isRightsHolder).foreach(author => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, author, DcxDaiAuthor toContributorValueObject))
         case node if node.label == "contributorDetails" && (node \ "organization").nonEmpty =>
           (node \ "organization").filterNot(DcxDaiOrganization inAnyOfRoles(List("RightsHolder", "Funder"))).foreach(organization => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, organization, DcxDaiOrganization toContributorValueObject))
+        case _ => // Do nothing
       }
 
       // Add contributors with role Funder as Grant Number with only an agency subfield
       contributors.foreach {
         case node if node.label == "contributorDetails" && (node \ "organization").nonEmpty =>
           (node \ "organization").filter(DcxDaiOrganization inAnyOfRoles(List("Funder"))).foreach(organization => addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, organization, DcxDaiOrganization toGrantNumberValueObject))
+        case _ => // Do nothing
       }
       addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isNwoGrantNumber), Identifier toNwoGrantNumberValue)
 

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
@@ -157,4 +157,27 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
           ))
     }
   }
+
+  it should "not trip over a contributor with an author element in it (DD-963)" in {
+    val ddm = <ddm:DDM>
+      <ddm:profile>
+          <dc:title>A title</dc:title>
+          <dc:description>Descr 1</dc:description>
+          <dc:description>Descr 2</dc:description>
+          <ddm:audience>D10000</ddm:audience>
+        </ddm:profile>
+        <ddm:dcmiMetadata>
+          <dct:rightsHolder>Mrs Rights</dct:rightsHolder>
+          <dcx-dai:contributorDetails>
+            <dcx-dai:author>
+               <dcx-dai:initials>J</dcx-dai:initials>
+               <dcx-dai:surname>Doe</dcx-dai:surname>
+            </dcx-dai:author>
+          </dcx-dai:contributorDetails>
+        </ddm:dcmiMetadata>
+      </ddm:DDM>
+
+    val result = mapper.toDataverseDataset(ddm, None, optAgreements, None, contactData, vaultMetadata)
+    result shouldBe a[Success[_]]
+  }
 }


### PR DESCRIPTION
DD-963

# Description of changes
* Added default cases for `foreach` statements where possibly none of the cases match.



# Notify

@DANS-KNAW/dataversedans
