### PR TITLE
DD-968. not mapping DANS and DANS-KNAW values in publisher

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -123,7 +123,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       }
       addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isNwoGrantNumber), Identifier toNwoGrantNumberValue)
 
-      addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, ddm \ "dcmiMetadata" \ "publisher", Publisher toDistributorValueObject)
+      addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, (ddm \ "dcmiMetadata" \ "publisher").filterNot(Publisher.isDans), Publisher toDistributorValueObject)
       addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
 
       addPrimitiveFieldSingleValue(citationFields, DATE_OF_DEPOSIT, optDateOfDeposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -123,7 +123,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       }
       addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isNwoGrantNumber), Identifier toNwoGrantNumberValue)
 
-      addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, (ddm \ "dcmiMetadata" \ "publisher").filterNot(Publisher.isDans), Publisher toDistributorValueObject)
+      addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, (ddm \ "dcmiMetadata" \ "publisher").filterNot(Publisher isDans), Publisher toDistributorValueObject)
       addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
 
       addPrimitiveFieldSingleValue(citationFields, DATE_OF_DEPOSIT, optDateOfDeposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Publisher.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Publisher.scala
@@ -15,9 +15,10 @@
  */
 package nl.knaw.dans.easy.dd2d.mapping
 
-import scala.xml.{ Elem, Node }
+import scala.xml.Node
 
 object Publisher extends BlockCitation {
+  private val dansNames = List("DANS", "DANS-KNAW", "DANS/KNAW")
 
   def toDistributorValueObject(node: Node): JsonObject = {
     val m = FieldMap()
@@ -27,5 +28,9 @@ object Publisher extends BlockCitation {
     m.addPrimitiveField(DISTRIBUTOR_ABBREVIATION, "")
     m.addPrimitiveField(DISTRIBUTOR_AFFILIATION, "")
     m.toJsonObject
+  }
+
+  def isDans(node: Node): Boolean = {
+    dansNames contains node.text
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
@@ -180,4 +180,125 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
     val result = mapper.toDataverseDataset(ddm, None, optAgreements, None, contactData, vaultMetadata)
     result shouldBe a[Success[_]]
   }
+
+  it should "not map publisher DANS-KNAW" in {
+    val ddm =
+      <ddm:DDM>
+          <ddm:profile>
+              <dc:title>A title</dc:title>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Dr</dcx-dai:titles>
+                      <dcx-dai:initials>A</dcx-dai:initials>
+                      <dcx-dai:insertions>van</dcx-dai:insertions>
+                      <dcx-dai:surname>Helsing</dcx-dai:surname>
+                      <dcx-dai:organization>
+                          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+                      </dcx-dai:organization>
+                  </dcx-dai:author>
+              </dcx-dai:creatorDetails>
+            <ddm:audience>D10000</ddm:audience>
+          </ddm:profile>
+          <ddm:dcmiMetadata>
+            <dct:rightsHolder>Mrs Rights</dct:rightsHolder>
+            <dct:publisher>DANS-KNAW</dct:publisher>
+          </ddm:dcmiMetadata>
+      </ddm:DDM>
+
+    val result = mapper.toDataverseDataset(ddm, None, optAgreements, None, contactData, vaultMetadata)
+    result shouldBe a[Success[_]]
+    inside(result) {
+      case Success(Dataset(dsv)) =>
+        val valueObjectsOfCompoundFields = dsv.metadataBlocks("citation").fields.filter(_.isInstanceOf[CompoundField]).map(_.asInstanceOf[CompoundField]).flatMap(_.value)
+        valueObjectsOfCompoundFields shouldNot contain(
+          Map(
+            "distributorName" -> PrimitiveSingleValueField("distributorName", "DANS-KNAW"),
+            "distributorAffiliation" -> PrimitiveSingleValueField("distributorAffiliation", ""),
+            "distributorAbbreviation" -> PrimitiveSingleValueField("distributorAbbreviation", ""),
+            "distributorURL" -> PrimitiveSingleValueField("distributorURL", ""),
+            "distributorLogoURL" -> PrimitiveSingleValueField("distributorLogoURL", "")
+          ))
+    }
+  }
+
+  it should "not map publisher DANS/KNAW" in {
+    val ddm =
+      <ddm:DDM>
+          <ddm:profile>
+              <dc:title>A title</dc:title>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Dr</dcx-dai:titles>
+                      <dcx-dai:initials>A</dcx-dai:initials>
+                      <dcx-dai:insertions>van</dcx-dai:insertions>
+                      <dcx-dai:surname>Helsing</dcx-dai:surname>
+                      <dcx-dai:organization>
+                          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+                      </dcx-dai:organization>
+                  </dcx-dai:author>
+              </dcx-dai:creatorDetails>
+            <ddm:audience>D10000</ddm:audience>
+          </ddm:profile>
+          <ddm:dcmiMetadata>
+            <dct:rightsHolder>Mrs Rights</dct:rightsHolder>
+            <dct:publisher>DANS-KNAW</dct:publisher>
+          </ddm:dcmiMetadata>
+      </ddm:DDM>
+
+    val result = mapper.toDataverseDataset(ddm, None, optAgreements, None, contactData, vaultMetadata)
+    result shouldBe a[Success[_]]
+    inside(result) {
+      case Success(Dataset(dsv)) =>
+        val valueObjectsOfCompoundFields = dsv.metadataBlocks("citation").fields.filter(_.isInstanceOf[CompoundField]).map(_.asInstanceOf[CompoundField]).flatMap(_.value)
+        valueObjectsOfCompoundFields shouldNot contain(
+          Map(
+            "distributorName" -> PrimitiveSingleValueField("distributorName", "DANS/KNAW"),
+            "distributorAffiliation" -> PrimitiveSingleValueField("distributorAffiliation", ""),
+            "distributorAbbreviation" -> PrimitiveSingleValueField("distributorAbbreviation", ""),
+            "distributorURL" -> PrimitiveSingleValueField("distributorURL", ""),
+            "distributorLogoURL" -> PrimitiveSingleValueField("distributorLogoURL", "")
+          ))
+    }
+  }
+
+  it should "map publisher (if not DANS) to distributor" in {
+    val ddm =
+      <ddm:DDM>
+          <ddm:profile>
+              <dc:title>A title</dc:title>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Dr</dcx-dai:titles>
+                      <dcx-dai:initials>A</dcx-dai:initials>
+                      <dcx-dai:insertions>van</dcx-dai:insertions>
+                      <dcx-dai:surname>Helsing</dcx-dai:surname>
+                      <dcx-dai:organization>
+                          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+                      </dcx-dai:organization>
+                  </dcx-dai:author>
+              </dcx-dai:creatorDetails>
+            <ddm:audience>D10000</ddm:audience>
+          </ddm:profile>
+          <ddm:dcmiMetadata>
+            <dct:rightsHolder>Mrs Rights</dct:rightsHolder>
+            <dct:publisher>PUBLISHER01</dct:publisher>
+          </ddm:dcmiMetadata>
+      </ddm:DDM>
+
+    val result = mapper.toDataverseDataset(ddm, None, optAgreements, None, contactData, vaultMetadata)
+    result shouldBe a[Success[_]]
+    inside(result) {
+      case Success(Dataset(dsv)) =>
+        val valueObjectsOfCompoundFields = dsv.metadataBlocks("citation").fields.filter(_.isInstanceOf[CompoundField]).map(_.asInstanceOf[CompoundField]).flatMap(_.value)
+        valueObjectsOfCompoundFields should contain(
+          Map(
+            "distributorName" -> PrimitiveSingleValueField("distributorName", "PUBLISHER01"),
+            "distributorAffiliation" -> PrimitiveSingleValueField("distributorAffiliation", ""),
+            "distributorAbbreviation" -> PrimitiveSingleValueField("distributorAbbreviation", ""),
+            "distributorURL" -> PrimitiveSingleValueField("distributorURL", ""),
+            "distributorLogoURL" -> PrimitiveSingleValueField("distributorLogoURL", "")
+          ))
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes DD-968

# Description of changes
Normally `dcmiMetadata / publisher` is mapped to a `distributor` (with only the name subfield filled in). This PR skips this mapping if the publisher is `DANS`, `DANS-KNAW` or `DANS/KNAW`.

# How to test
* Added unit tests to `src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala`.

# Notify

@DANS-KNAW/dataversedans
