### PR TITLE
DD-993 dd-ingest-flow skips non TechInfo descriptions under dcmiMetadata

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -84,6 +84,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       addCompoundFieldMultipleValues(citationFields, DESCRIPTION, ddm \ "profile" \ "description", Description toDescriptionValueObject)
       addCompoundFieldMultipleValues(citationFields, DESCRIPTION, if (alternativeTitles.isEmpty) NodeSeq.Empty
                                                                   else alternativeTitles.tail, Description toDescriptionValueObject)
+      addCompoundFieldMultipleValues(citationFields, DESCRIPTION, (ddm \ "dcmiMetadata" \ "description").filterNot(Description isTechnicalInfo), Description toDescriptionValueObject)
       val otherDescriptions =
         (ddm \ "dcmiMetadata" \ "date") ++
         (ddm \ "dcmiMetadata" \ "dateAccepted") ++


### PR DESCRIPTION
Fixes DD-993

# Description of changes
Add `dcmiMetadata/description` elements without the descriptionType = TechnicalInfo. 

# How to test
Import a deposit that has `dcmiMetadata/description` elements without attributes and check that the descriptions are added as Dataverse Citation Metadata descriptions.


# Notify

@DANS-KNAW/dataversedans
