### PR TITLE
DD-995 Use DANS BagIt Profile v1

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -17,7 +17,8 @@ package nl.knaw.dans.easy.dd2d
 
 import better.files.File
 import nl.knaw.dans.easy.dd2d.OutboxSubdir.{ FAILED, OutboxSubdir, PROCESSED, REJECTED }
-import nl.knaw.dans.easy.dd2d.dansbag.{ DansBagValidationResult, DansBagValidator }
+import nl.knaw.dans.easy.dd2d.dansbag.InformationPackageType.InformationPackageType
+import nl.knaw.dans.easy.dd2d.dansbag.{ DansBagValidationResult, DansBagValidator, InformationPackageType }
 import nl.knaw.dans.easy.dd2d.mapping.JsonObject
 import nl.knaw.dans.easy.dd2d.migrationinfo.MigrationInfo
 import nl.knaw.dans.lib.dataverse.DataverseInstance
@@ -63,6 +64,8 @@ case class DepositIngestTask(deposit: Deposit,
                              repordIdToTerm: Map[String, String],
                              outboxDir: File) extends Task[Deposit] with DebugEnhancedLogging {
   trace(deposit)
+  protected val informationPackageType: InformationPackageType = InformationPackageType.SIP
+  protected val bagProfileVersion: Int = 1
 
   private val datasetMetadataMapper = new DepositToDvDatasetMetadataMapper(deduplicate, activeMetadataBlocks, narcisClassification, iso1ToDataverseLanguage, iso2ToDataverseLanguage, repordIdToTerm)
   private val bagDirPath = File(deposit.bagDir.path)
@@ -122,7 +125,7 @@ case class DepositIngestTask(deposit: Deposit,
     optDansBagValidator.map {
       dansBagValidator =>
         for {
-          validationResult <- dansBagValidator.validateBag(bagDirPath)
+          validationResult <- dansBagValidator.validateBag(bagDirPath, informationPackageType, bagProfileVersion)
           _ <- rejectIfInvalid(validationResult)
         } yield ()
     }.getOrElse({

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -16,7 +16,8 @@
 package nl.knaw.dans.easy.dd2d
 
 import better.files.File
-import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator
+import nl.knaw.dans.easy.dd2d.dansbag.{ DansBagValidator, InformationPackageType }
+import nl.knaw.dans.easy.dd2d.dansbag.InformationPackageType.InformationPackageType
 import nl.knaw.dans.easy.dd2d.mapping.Amd
 import nl.knaw.dans.easy.dd2d.migrationinfo.MigrationInfo
 import nl.knaw.dans.lib.dataverse.DataverseInstance
@@ -64,6 +65,7 @@ class DepositMigrationTask(deposit: Deposit,
     supportedLicenses,
     repordIdToTerm,
     outboxDir) {
+  override protected val informationPackageType: InformationPackageType = InformationPackageType.AIP
 
   override protected def checkDepositType(): Try[Unit] = {
     for {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidator.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.dd2d.dansbag
 
 import better.files.File
+import nl.knaw.dans.easy.dd2d.dansbag.InformationPackageType.InformationPackageType
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import scalaj.http.Http
 
@@ -39,10 +40,10 @@ class DansBagValidator(serviceUri: URI, connTimeoutMs: Int, readTimeoutMs: Int) 
     }
   }
 
-  def validateBag(bagDir: File): Try[DansBagValidationResult] = {
+  def validateBag(bagDir: File, informationPackageType: InformationPackageType, profileVersion: Int): Try[DansBagValidationResult] = {
     trace(bagDir)
     Try {
-      val validationUri = serviceUri.resolve(s"validate?infoPackageType=SIP&uri=${ bagDir.path.toUri }")
+      val validationUri = serviceUri.resolve(s"validate?infoPackageType=$informationPackageType&profileVersion=$profileVersion&uri=${ bagDir.path.toUri }")
       logger.debug(s"Calling Dans Bag Validation Service with ${ validationUri.toASCIIString }")
       Http(s"${ validationUri.toASCIIString }")
         .timeout(connTimeoutMs, readTimeoutMs)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
@@ -32,7 +32,6 @@ object Description extends BlockCitation {
   def toDescriptionValueObject(node: Node): JsonObject = {
     val m = FieldMap()
     m.addPrimitiveField(DESCRIPTION_VALUE, newlineToHtml(node.text))
-    // TODO: add date subfield?
     m.toJsonObject
   }
 


### PR DESCRIPTION
Fixes DD-995

# Description of changes
* Made sure `dd-ingest-flow` always uses DANS BagIt Profile version 1
* Migration tasks use the AIP rules
* Import tasks (SWORD2, bulk-import) use the SIP rules.

# Related PRs
https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/115

# Notify

@DANS-KNAW/dataversedans
