### PR TITLE
DD-999: part 3 - replace dataverse library (scala to java) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.0.18-SNAPSHOT</version>
+            <version>0.0.18</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.0.17</version>
+            <version>0.0.18-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -46,12 +46,12 @@ class DatasetCreator(deposit: Deposit,
 
   override def performEdit(): Try[PersistentId] = {
     {
-      val dataverseApi = dataverseInstance.dataverse("root")
+      val scalaDataverseApi = dataverseInstance.dataverse("root")
       for {
         // autoPublish is false, because it seems there is a bug with it in Dataverse (most of the time?)
         response <- if (isMigration)
-                      dataverseApi.importDataset(dataverseDataset, Some(s"doi:${ deposit.doi }"), autoPublish = false)
-                    else dataverseApi.createDataset(dataverseDataset)
+                      scalaDataverseApi.importDataset(dataverseDataset, Some(s"doi:${ deposit.doi }"), autoPublish = false)
+                    else scalaDataverseApi.createDataset(dataverseDataset)
         persistentId <- response.data.map(_.persistentId)
       } yield persistentId
     } match {
@@ -59,20 +59,21 @@ class DatasetCreator(deposit: Deposit,
       case Success(persistentId) => {
         for {
           licenseAsJson <- licenseAsJson(supportedLicenses)(variantToLicense)(deposit)
-          _ <- Try(dataverseClient.dataset(persistentId).updateMetadataFromJsonLd(licenseAsJson, true))
-          _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
+          javaDatasetApi <- Try(dataverseClient.dataset(persistentId))
+          _ <- Try(javaDatasetApi.updateMetadataFromJsonLd(licenseAsJson, true))
+          _ <- Try(javaDatasetApi.awaitUnlock())
           pathToFileInfo <- getPathToFileInfo(deposit)
           prestagedFiles <- optMigrationInfoService.map(_.getPrestagedDataFilesFor(s"doi:${ deposit.doi }", 1)).getOrElse(Success(Set.empty[BasicFileMeta]))
           databaseIdsToFileInfo <- addFiles(persistentId, pathToFileInfo.values.toList, prestagedFiles)
           _ <- updateFileMetadata(databaseIdsToFileInfo.mapValues(_.metadata))
-          _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
+          _ <- Try(javaDatasetApi.awaitUnlock())
           _ <- configureEnableAccessRequests(deposit, persistentId, canEnable = true)
-          _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
+          _ <- Try(javaDatasetApi.awaitUnlock())
           _ = debug(s"Assigning role $depositorRole to ${ deposit.depositorUserId }")
           scalaRoleAssignment = RoleAssignment(s"@${ deposit.depositorUserId }", depositorRole)
           jsonRoleAssignment = Serialization.write(scalaRoleAssignment)
-          _ <- Try(dataverseClient.dataset(persistentId).assignRole(jsonRoleAssignment))
-          _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
+          _ <- Try(javaDatasetApi.assignRole(jsonRoleAssignment))
+          _ <- Try(javaDatasetApi.awaitUnlock())
           dateAvailable <- deposit.getDateAvailable
           _ <- embargoFiles(persistentId, dateAvailable)
         } yield persistentId
@@ -96,7 +97,7 @@ class DatasetCreator(deposit: Deposit,
         ids = response.filter(f => "easy-migration" != f.getDirectoryLabel)
           .map(f => f.getDataFile.getId).toList
         _ <- embargoFiles(persistentId, dateAvailable, ids)
-        _ <- Try(dataverseInstance.dataset(persistentId).awaitUnlock())
+        _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
       } yield ()
     }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -17,12 +17,15 @@ package nl.knaw.dans.easy.dd2d
 
 import nl.knaw.dans.easy.dd2d.mapping.{ AccessRights, License }
 import nl.knaw.dans.easy.dd2d.migrationinfo.BasicFileMeta
+import nl.knaw.dans.lib.dataverse.DataverseClient
+import nl.knaw.dans.lib.error.{ TraversableTryExtensions, TryExtensions }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.scaladv.DataverseInstance
 import nl.knaw.dans.lib.scaladv.model.dataset.Embargo
 import nl.knaw.dans.lib.scaladv.model.file.FileMeta
 import nl.knaw.dans.lib.scaladv.model.file.prestaged.PrestagedFile
-import nl.knaw.dans.lib.scaladv.{ DatasetApi, DataverseInstance }
-import nl.knaw.dans.lib.error.{ TraversableTryExtensions, TryExtensions }
-import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.json4s.native.Serialization
+import org.json4s.{ DefaultFormats, Formats }
 
 import java.net.URI
 import java.nio.file.{ Path, Paths }
@@ -34,9 +37,10 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Object that edits a dataset, a new draft.
  */
-abstract class DatasetEditor(dataverseInstance: DataverseInstance, optFileExclusionPattern: Option[Pattern], zipFileHandler: ZipFileHandler) extends DebugEnhancedLogging {
+abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClient: DataverseClient, optFileExclusionPattern: Option[Pattern], zipFileHandler: ZipFileHandler) extends DebugEnhancedLogging {
   type PersistentId = String
   type DatasetId = Int
+  implicit val jsonFormats: Formats = DefaultFormats
 
   /**
    * Performs the task.
@@ -83,7 +87,7 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, optFileExclus
   protected def getPathToFileInfo(deposit: Deposit): Try[Map[Path, FileInfo]] = {
     for {
       bagPathToFileInfo <- deposit.getPathToFileInfo
-      pathToFileInfo = bagPathToFileInfo.map { case (bagPath, fileInfo) => (Paths.get("data").relativize(bagPath) -> fileInfo) }
+      pathToFileInfo = bagPathToFileInfo.map { case (bagPath, fileInfo) => Paths.get("data").relativize(bagPath) -> fileInfo }
       filteredPathToFileInfo = excludeFiles(pathToFileInfo)
     } yield filteredPathToFileInfo
   }
@@ -112,11 +116,10 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, optFileExclus
 
   protected def updateFileMetadata(databaseIdToFileInfo: Map[Int, FileMeta]): Try[Unit] = {
     trace(databaseIdToFileInfo)
-    databaseIdToFileInfo.map { case (id, fileMeta) => {
+    databaseIdToFileInfo.map { case (id, fileMeta) =>
       val r = dataverseInstance.file(id).updateMetadata(fileMeta)
       debug(s"id = $id, result = $r")
       r
-    }
     }.collectResults.map(_ => ())
   }
 
@@ -143,21 +146,15 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, optFileExclus
                 |""".stripMargin
   }
 
-  protected def getFilesToEmbargo(persistendId: PersistentId): Try[List[FileMeta]] = {
-    for {
-      r <- dataverseInstance.dataset(persistendId).listFiles()
-      files <- r.data
-      filesToEmbargo = files.filter(f => f.directoryLabel.getOrElse("") != "easy-migration")
-    } yield filesToEmbargo
-  }
-
   protected def isEmbargo(date: Date): Boolean = {
     date.compareTo(new Date()) > 0
   }
 
   protected def embargoFiles(persistendId: PersistentId, dateAvailable: Date, fileIds: List[Int]): Try[Unit] = {
     trace(persistendId, fileIds)
-    dataverseInstance.dataset(persistendId).setEmbargo(Embargo(dateAvailableFormat.format(dateAvailable), "", fileIds)).map(_ => ())
+    val embargo = Embargo(dateAvailableFormat.format(dateAvailable), "", fileIds)
+    val json = Serialization.write(embargo)
+    Try(dataverseClient.dataset(persistendId).setEmbargo(json))
   }
 
   protected def deleteDraftIfExists(persistentId: String): Unit = {
@@ -175,7 +172,7 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, optFileExclus
 
   private def deleteDraft(persistentId: PersistentId): Try[Unit] = {
     for {
-      r <- dataverseInstance.dataset(persistentId).deleteDraft()
+      _ <- dataverseInstance.dataset(persistentId).deleteDraft()
       _ = logger.info(s"DRAFT deleted")
     } yield ()
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -126,10 +126,9 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
       files <- deposit.tryFilesXml
       enable = AccessRights.isEnableRequests((ddm \ "profile" \ "accessRights").head, files)
       _ = logger.trace("AccessRequests enable "+ enable + " can " +canEnable)
-      _ <- if (enable && canEnable) dataverseInstance.accessRequests(persistendId).enable()
-           else Success(())
-      _ <- if (!enable) dataverseInstance.accessRequests(persistendId).disable()
-           else Success(())
+      _ <- if (!enable) Try(dataverseClient.accessRequests(persistendId).disable())
+           else if (canEnable) Try(dataverseClient.accessRequests(persistendId).enable())
+                else Success(())
     } yield ()
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -173,7 +173,7 @@ class DatasetUpdater(deposit: Deposit,
       }.doIfFailure {
         case _: CannotUpdateDraftDatasetException => // Don't delete the draft that caused the failure
         case NonFatal(e) =>
-          logger.error("Dataset update failed, deleting draft", e)
+          logger.error(s"Dataset update failed, deleting draft $e", e)
           deleteDraftIfExists(doi)
       }
     }
@@ -263,11 +263,11 @@ class DatasetUpdater(deposit: Deposit,
   }
 
   private def deleteFiles(dataset: DatasetApi, databaseIds: List[DatabaseId]): Try[Unit] = {
-    databaseIds.map(id => {
+    databaseIds.map { id =>
       debug(s"Deleting file, databaseId = $id")
-      dataverseInstance.sword().deleteFile(id)
+      dataverseClient.sword().deleteFile(id)
       dataset.awaitUnlock()
-    }).collectResults.map(_ => ())
+    }.collectResults.map(_ => ())
   }
 
   private def replaceFiles(dataset: DatasetApi, databaseIdToNewFile: Map[Int, FileInfo], prestagedFiles: Set[BasicFileMeta] = Set.empty): Try[Map[Int, FileMeta]] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.dd2d
 
 import nl.knaw.dans.easy.dd2d.migrationinfo.{ BasicFileMeta, MigrationInfo }
+import nl.knaw.dans.lib.dataverse.DataverseClient
 import nl.knaw.dans.lib.scaladv.model.dataset.MetadataBlocks
 import nl.knaw.dans.lib.scaladv.model.file.FileMeta
 import nl.knaw.dans.lib.scaladv.model.search.DatasetResultItem
@@ -39,7 +40,8 @@ class DatasetUpdater(deposit: Deposit,
                      variantToLicense: Map[String, String],
                      supportedLicenses: List[URI],
                      dataverseInstance: DataverseInstance,
-                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseInstance, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
+                     dataverseClient: DataverseClient,
+                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseInstance, dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
   trace(deposit)
 
   override def performEdit(): Try[PersistentId] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -173,7 +173,7 @@ class DatasetUpdater(deposit: Deposit,
       }.doIfFailure {
         case _: CannotUpdateDraftDatasetException => // Don't delete the draft that caused the failure
         case NonFatal(e) =>
-          logger.error(s"Dataset update failed, deleting draft $e", e)
+          logger.error(s"Dataset update failed, deleting draft", e)
           deleteDraftIfExists(doi)
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -47,6 +47,7 @@ class DatasetUpdater(deposit: Deposit,
   override def performEdit(): Try[PersistentId] = {
     {
       for {
+        - <- Try { Thread.sleep(4000) }
         doi <- if (isMigration) getDoiByIsVersionOf // using deposit.dataversePid may lead to confusing situations when the DOI is present but erroneously so.
                else getDoiBySwordToken
       } yield doi
@@ -60,7 +61,7 @@ class DatasetUpdater(deposit: Deposit,
            * Temporary fix. If we do not wait a couple of seconds here, the first version never gets properly published, and the second version
            * just overwrites it, becoming V1.
            */
-          - <- Try { Thread.sleep(3000) }
+          - <- Try { Thread.sleep(6000) }
           // TODO: library should provide function waitForIndexing that uses the @Path("{identifier}/timestamps") endpoint on Datasets
           _ <- dataset.awaitUnlock()
           _ <- checkDatasetInPublishedState(dataset)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -245,7 +245,7 @@ case class DepositIngestTask(deposit: Deposit,
   private def savePersistentIdentifiersInDepositProperties(persistentId: String): Try[Unit] = {
     implicit val jsonFormats: Formats = DefaultFormats
     for {
-      _ <- Try(dataverseClient.dataset(persistentId).awaitUnlock())
+      _ <- dataverseInstance.dataset(persistentId).awaitUnlock()
       _ = debug(s"Dataset $persistentId is not locked")
       _ <- deposit.setDoi(persistentId)
       r <- dataverseInstance.dataset(persistentId).view()

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -189,7 +189,7 @@ case class DepositIngestTask(deposit: Deposit,
   }
 
   protected def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, Option.empty)
+    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, Option.empty)
   }
 
   protected def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -79,7 +79,7 @@ class DepositMigrationTask(deposit: Deposit,
   }
 
   override def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, migrationInfo)
+    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, migrationInfo)
   }
 
   override def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -95,6 +95,12 @@ logging:
       additive: true
     "nl.knaw.dans.ingest.core.service.UnboundedDepositsImportTaskIterator":
       level: INFO
+    "nl.knaw.dans.easy.dd2d":
+      level: TRACE
+    "nl.knaw.dans.scaladv.DatasetApi":
+      level: TRACE
+    "nl.knaw.dans.dataverse.DatasetApi":
+      level: TRACE
   appenders:
     - type: console
       logFormat: "%-5p [%d{ISO8601}] [%t] %c: %m%n%rEx"


### PR DESCRIPTION
Fixes DD-999: part 3 - replace dataverse library (scala to java) 

# Description of changes

# How to test

# Related PRs

* [x] need release of https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/25

# Notify

@DANS-KNAW/dataversedans
