### PR TITLE
DD-999: part 4 - replace dataverse library (scala to java)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.0.18</version>
+            <version>0.0.19-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.0.19-SNAPSHOT</version>
+            <version>0.0.19</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/java/nl/knaw/dans/ingest/core/legacy/MapperForScala.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/legacy/MapperForScala.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.legacy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import nl.knaw.dans.lib.dataverse.DataverseItemDeserializer;
+import nl.knaw.dans.lib.dataverse.MetadataFieldDeserializer;
+import nl.knaw.dans.lib.dataverse.ResultItemDeserializer;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
+import nl.knaw.dans.lib.dataverse.model.dataverse.DataverseItem;
+import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
+
+public class MapperForScala {
+
+    public static ObjectMapper get() {
+        return mapper;
+    }
+
+    private static ObjectMapper mapper = init();
+
+    public static ObjectMapper init () {
+        mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        // jsonSerializer.readValue(s,  classManifest[T].erasure).asInstanceOf[T]
+        module.addDeserializer(MetadataField.class, new MetadataFieldDeserializer());
+        module.addDeserializer(DataverseItem.class, new DataverseItemDeserializer());
+        module.addDeserializer(ResultItem.class, new ResultItemDeserializer(mapper));
+        mapper.registerModule(module);
+        return mapper;
+    }
+}

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -21,7 +21,7 @@ import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.scaladv.model.RoleAssignment
 import nl.knaw.dans.lib.scaladv.model.dataset.Dataset
-import nl.knaw.dans.lib.scaladv.{ DataverseInstance, Version, serializeAsJson }
+import nl.knaw.dans.lib.scaladv.{ Version, serializeAsJson }
 import org.json4s.native.Serialization
 
 import java.net.URI
@@ -39,7 +39,6 @@ class DatasetCreator(deposit: Deposit,
                      dataverseDataset: Dataset,
                      variantToLicense: Map[String, String],
                      supportedLicenses: List[URI],
-                     dataverseInstance: DataverseInstance,
                      dataverseClient: DataverseClient,
                      optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
   trace(deposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -41,7 +41,7 @@ class DatasetCreator(deposit: Deposit,
                      supportedLicenses: List[URI],
                      dataverseInstance: DataverseInstance,
                      dataverseClient: DataverseClient,
-                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseInstance, dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
+                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
   trace(deposit)
 
   override def performEdit(): Try[PersistentId] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -21,12 +21,12 @@ import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.scaladv.model.RoleAssignment
 import nl.knaw.dans.lib.scaladv.model.dataset.Dataset
-import nl.knaw.dans.lib.scaladv.{ DataverseInstance, Version }
+import nl.knaw.dans.lib.scaladv.{ DataverseInstance, Version, serializeAsJson }
 import org.json4s.native.Serialization
 
 import java.net.URI
-import java.util.Date
 import java.util.regex.Pattern
+import java.util.{ Date, Optional }
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
@@ -46,13 +46,15 @@ class DatasetCreator(deposit: Deposit,
 
   override def performEdit(): Try[PersistentId] = {
     {
-      val scalaDataverseApi = dataverseInstance.dataverse("root")
+      val javaDataverseApi = dataverseClient.dataverse("root")
       for {
+        jsonString <- serializeAsJson(dataverseDataset, logger.underlying.isDebugEnabled)
         // autoPublish is false, because it seems there is a bug with it in Dataverse (most of the time?)
-        response <- if (isMigration)
-                      scalaDataverseApi.importDataset(dataverseDataset, Some(s"doi:${ deposit.doi }"), autoPublish = false)
-                    else scalaDataverseApi.createDataset(dataverseDataset)
-        persistentId <- response.data.map(_.persistentId)
+        response <- Try(if (isMigration)
+                          javaDataverseApi.importDataset(jsonString, Optional.of(s"doi:${ deposit.doi }"), false)
+                        else javaDataverseApi.createDataset(jsonString)
+        )
+        persistentId <- Try(response.getData).map(_.getPersistentId)
       } yield persistentId
     } match {
       case Failure(e) => Failure(FailedDepositException(deposit, "Could not import/create dataset", e))

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -114,7 +114,9 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
   protected def updateFileMetadata(databaseIdToFileInfo: Map[Int, FileMeta]): Try[Unit] = {
     trace(databaseIdToFileInfo)
     databaseIdToFileInfo.map { case (id, fileMeta) =>
-      val r = dataverseInstance.file(id).updateMetadata(fileMeta)
+      val json = Serialization.write(fileMeta)
+      debug(s"id = $id, json = $json")
+      val r = Try(dataverseClient.file(id).updateMetadata(json))
       debug(s"id = $id, result = $r")
       r
     }.collectResults.map(_ => ())

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -63,7 +63,7 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
   private def addFile(doi: String, fileInfo: FileInfo, prestagedFiles: Set[BasicFileMeta]): Try[Int] = {
     val result = for {
       r <- getPrestagedFileFor(fileInfo, prestagedFiles).map { prestagedFile =>
-        logger.info(s"Adding prestaged file (not tested): $fileInfo") // TODO
+        logger.info(s"Adding prestaged file (scala -> java change not tested): $fileInfo") // TODO
         Try(dataverseClient.dataset(doi).addFileItem(
           Optional.of(noFile),
           Optional.of(Serialization.write(prestagedFile))
@@ -164,6 +164,7 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
   protected def deleteDraftIfExists(persistentId: String): Unit = {
     val result = for {
       v <- Try(dataverseClient.dataset(persistentId).viewLatestVersion().getData)
+      _ = logger.trace("deleting draft")
       _ <- if (v.getLatestVersion.getVersionState.contains("DRAFT"))
              deleteDraft(persistentId)
            else Success(())
@@ -175,7 +176,7 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
 
   private def deleteDraft(persistentId: PersistentId): Try[Unit] = {
     for {
-      _ <- dataverseInstance.dataset(persistentId).deleteDraft()
+      _ <- Try(dataverseClient.dataset(persistentId).deleteDraft())
       _ = logger.info(s"DRAFT deleted")
     } yield ()
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -36,7 +36,7 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Object that edits a dataset, a new draft.
  */
-abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClient: DataverseClient, optFileExclusionPattern: Option[Pattern], zipFileHandler: ZipFileHandler) extends DebugEnhancedLogging {
+abstract class DatasetEditor(dataverseClient: DataverseClient, optFileExclusionPattern: Option[Pattern], zipFileHandler: ZipFileHandler) extends DebugEnhancedLogging {
   type PersistentId = String
   type DatasetId = Int
   implicit val jsonFormats: Formats = DefaultFormats

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -62,14 +62,14 @@ abstract class DatasetEditor(dataverseInstance: DataverseInstance, dataverseClie
     val result = for {
       r <- getPrestagedFileFor(fileInfo, prestagedFiles).map { prestagedFile =>
         debug(s"Adding prestaged file: $fileInfo")
-        dataverseInstance.dataset(doi).addPrestagedFile(prestagedFile)
+        dataverseInstance.dataset(doi).addFileItem(Option.empty, Option(Serialization.write(prestagedFile)))
       }.getOrElse {
         debug(s"Uploading file: $fileInfo")
         val optWrappedZip = zipFileHandler
           .wrapIfZipFile(fileInfo.file)
-        val r = dataverseInstance.dataset(doi).addFile(Option(
+        val r = dataverseInstance.dataset(doi).addFileItem(Option(
           optWrappedZip
-            .getOrElse(fileInfo.file)), Option(fileInfo.metadata))
+            .getOrElse(fileInfo.file)), Option(Serialization.write(fileInfo.metadata)))
         optWrappedZip.foreach(_.delete(swallowIOExceptions = true))
         r
       }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -20,7 +20,6 @@ import nl.knaw.dans.easy.dd2d.migrationinfo.BasicFileMeta
 import nl.knaw.dans.lib.dataverse.DataverseClient
 import nl.knaw.dans.lib.error.{ TraversableTryExtensions, TryExtensions }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import nl.knaw.dans.lib.scaladv.DataverseInstance
 import nl.knaw.dans.lib.scaladv.model.dataset.Embargo
 import nl.knaw.dans.lib.scaladv.model.file.FileMeta
 import nl.knaw.dans.lib.scaladv.model.file.prestaged.PrestagedFile

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -16,13 +16,15 @@
 package nl.knaw.dans.easy.dd2d
 
 import nl.knaw.dans.easy.dd2d.migrationinfo.{ BasicFileMeta, MigrationInfo }
-import nl.knaw.dans.lib.dataverse.DataverseClient
+import nl.knaw.dans.ingest.core.legacy.MapperForScala
+import nl.knaw.dans.lib.dataverse._
+import nl.knaw.dans.lib.dataverse.model.file.{ FileMeta => JavaFileMeta }
 import nl.knaw.dans.lib.dataverse.model.search
 import nl.knaw.dans.lib.error.{ TraversableTryExtensions, TryExtensions }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.scaladv.model.dataset.MetadataBlocks
-import nl.knaw.dans.lib.scaladv.model.file.FileMeta
-import nl.knaw.dans.lib.scaladv.{ DatasetApi, DataverseInstance, Version }
+import nl.knaw.dans.lib.scaladv.model.file.{ FileMeta => ScalaFileMeta }
+import nl.knaw.dans.lib.scaladv.{ DataverseInstance, Version }
 import org.json4s.native.Serialization
 
 import java.net.URI
@@ -81,8 +83,7 @@ class DatasetUpdater(deposit: Deposit,
 
           pathToFileInfo <- getPathToFileInfo(deposit)
           _ = debug(s"pathToFileInfo = $pathToFileInfo")
-          scalaDatasetApi <- Try { dataverseInstance.dataset(doi) }
-          pathToFileMetaInLatestVersion <- getFilesInLatestVersion(scalaDatasetApi)
+          pathToFileMetaInLatestVersion <- getFilesInLatestVersion(javaDatasetApi)
           _ = debug(s"pathToFileMetaInLatestVersion = $pathToFileMetaInLatestVersion")
           _ <- validateFileMetas(pathToFileMetaInLatestVersion.values.toList)
 
@@ -109,7 +110,7 @@ class DatasetUpdater(deposit: Deposit,
             .filterNot { case (path, _) => oldToNewPathMovedFiles.keySet.contains(path) } // remove old paths of moved files
             .filterNot { case (path, _) => oldToNewPathMovedFiles.values.toSet.contains(path) } // remove new paths of moved files
           filesToReplace <- getFilesToReplace(pathToFileInfo, fileReplacementCandidates)
-          fileReplacements <- replaceFiles(scalaDatasetApi, filesToReplace, prestagedFiles)
+          fileReplacements <- replaceFiles(javaDatasetApi, filesToReplace, prestagedFiles)
           _ = debug(s"fileReplacements = $fileReplacements")
 
           /*
@@ -128,7 +129,7 @@ class DatasetUpdater(deposit: Deposit,
           _ = debug(s"pathsToDelete = $pathsToDelete")
           fileDeletions <- getFileDeletions(pathsToDelete, pathToFileMetaInLatestVersion)
           _ = debug(s"fileDeletions = $fileDeletions")
-          _ <- deleteFiles(scalaDatasetApi, fileDeletions.toList)
+          _ <- deleteFiles(javaDatasetApi, fileDeletions.toList)
 
           /*
            * After the movements have been performed, which paths are occupied? We start from the paths of the latest version (pathToFileMetaInLatestVersion.keySet)
@@ -197,25 +198,29 @@ class DatasetUpdater(deposit: Deposit,
     } yield doi
   }
 
-  private def getFilesInLatestVersion(dataset: DatasetApi): Try[Map[Path, FileMeta]] = {
+  private def getFilesInLatestVersion(dataset: DatasetApi): Try[Map[Path, ScalaFileMeta]] = {
     for {
-      response <- dataset.listFiles(Version.LATEST_PUBLISHED) // N.B. If LATEST_PUBLISHED is not specified, it almost works, but the directoryLabel is not picked up somehow.
-      files <- response.data
-      pathToFileMeta = files.map(f => (getPathFromFileMeta(f), f)).toMap
+      response <- Try(dataset.getFiles(Version.LATEST_PUBLISHED.toString())) // N.B. If LATEST_PUBLISHED is not specified, it almost works, but the directoryLabel is not picked up somehow.
+      files <- Try(response.getData)
+      pathToFileMeta = files.map { javaFileMeta =>
+        val str = MapperForScala.get().writeValueAsString(javaFileMeta)
+        val scalaFileMeta: ScalaFileMeta = Serialization.read[ScalaFileMeta](str)
+        (getPathFromFileMeta(javaFileMeta), scalaFileMeta)
+      }.toMap
     } yield pathToFileMeta
   }
 
-  private def getPathFromFileMeta(fileMeta: FileMeta): Path = {
-    Paths.get(fileMeta.directoryLabel.getOrElse(""), fileMeta.label.getOrElse(""))
+  private def getPathFromFileMeta(fileMeta: JavaFileMeta): Path = {
+    Paths.get(fileMeta.getDirectoryLabel, fileMeta.getLabel)
   }
 
-  private def validateFileMetas(files: List[FileMeta]): Try[Unit] = {
+  private def validateFileMetas(files: List[ScalaFileMeta]): Try[Unit] = {
     if (files.map(_.dataFile).exists(_.isEmpty)) Failure(new IllegalArgumentException("Found file metadata without dataFile element"))
     else if (files.map(_.dataFile.get).exists(_.checksum.`type` != "SHA-1")) Failure(new IllegalArgumentException("Not all file checksums are of type SHA-1"))
          else Success(())
   }
 
-  private def getFilesToReplace(pathToFileInfo: Map[Path, FileInfo], pathToFileMetaInLatestVersion: Map[Path, FileMeta]): Try[Map[Int, FileInfo]] = Try {
+  private def getFilesToReplace(pathToFileInfo: Map[Path, FileInfo], pathToFileMetaInLatestVersion: Map[Path, ScalaFileMeta]): Try[Map[Int, FileInfo]] = Try {
     trace(())
     val intersection = pathToFileInfo.keySet intersect pathToFileMetaInLatestVersion.keySet
     debug(s"The following files are in both deposit and latest published version: ${ intersection.mkString(", ") }")
@@ -234,7 +239,7 @@ class DatasetUpdater(deposit: Deposit,
    * @param pathToFileInfo                map from path to file info in the new version (i.e. the deposit).
    * @return
    */
-  private def getOldToNewPathOfFilesToMove(pathToFileMetaInLatestVersion: Map[Path, FileMeta], pathToFileInfo: Map[Path, FileInfo]): Try[Map[Path, Path]] = {
+  private def getOldToNewPathOfFilesToMove(pathToFileMetaInLatestVersion: Map[Path, ScalaFileMeta], pathToFileInfo: Map[Path, FileInfo]): Try[Map[Path, Path]] = {
     for {
       checksumsToPathNonDuplicatedFilesInDeposit <- getChecksumsToPathOfNonDuplicateFiles(pathToFileInfo.mapValues(_.checksum))
       checksumsToPathNonDuplicatedFilesInLatestVersion <- getChecksumsToPathOfNonDuplicateFiles(pathToFileMetaInLatestVersion.mapValues(_.dataFile.get.checksum.value))
@@ -258,7 +263,7 @@ class DatasetUpdater(deposit: Deposit,
       .map { case (c, m) => (c, m.head._1) }
   }
 
-  private def getFileDeletions(paths: Set[Path], pathToFileMeta: Map[Path, FileMeta]): Try[Set[Int]] = Try {
+  private def getFileDeletions(paths: Set[Path], pathToFileMeta: Map[Path, ScalaFileMeta]): Try[Set[Int]] = Try {
     paths.map(path => pathToFileMeta(path).dataFile.get.id)
   }
 
@@ -266,17 +271,17 @@ class DatasetUpdater(deposit: Deposit,
     databaseIds.map { id =>
       debug(s"Deleting file, databaseId = $id")
       dataverseClient.sword().deleteFile(id)
-      dataset.awaitUnlock()
+      Try(dataset.awaitUnlock())
     }.collectResults.map(_ => ())
   }
 
-  private def replaceFiles(dataset: DatasetApi, databaseIdToNewFile: Map[Int, FileInfo], prestagedFiles: Set[BasicFileMeta] = Set.empty): Try[Map[Int, FileMeta]] = {
+  private def replaceFiles(dataset: DatasetApi, databaseIdToNewFile: Map[Int, FileInfo], prestagedFiles: Set[BasicFileMeta] = Set.empty): Try[Map[Int, ScalaFileMeta]] = {
     trace(databaseIdToNewFile, prestagedFiles)
     databaseIdToNewFile.map {
       case (id, fileInfo) =>
         val fileApi = dataverseInstance.file(id)
 
-        def replaceFile(prestagedFiles: Set[BasicFileMeta]): Try[(Int, FileMeta)] = {
+        def replaceFile(prestagedFiles: Set[BasicFileMeta]): Try[(Int, ScalaFileMeta)] = {
           /*
            * Note, forceReplace = true is used, so that the action does not fail if the replacement has a different MIME-type than
            * the replaced file. The only way to pass forceReplace is through the FileMeta. This means we are deleting any existing
@@ -289,7 +294,7 @@ class DatasetUpdater(deposit: Deposit,
               fileApi.replaceWithPrestagedFile(prestagedFile.copy(forceReplace = true))
             }.getOrElse {
               debug(s"Uploading replacement file: $fileInfo")
-              fileApi.replace(Option(fileInfo.file), Option(FileMeta(forceReplace = true)))
+              fileApi.replace(Option(fileInfo.file), Option(ScalaFileMeta(forceReplace = true)))
             }
             fileList <- r.data
             id = fileList.files.head.dataFile.map(_.id).getOrElse(throw new IllegalStateException("Could not get ID of replacement file after replace action"))
@@ -297,7 +302,7 @@ class DatasetUpdater(deposit: Deposit,
         }
         for {
           (replacementId, replacementMeta) <- replaceFile(prestagedFiles)
-          _ <- dataset.awaitUnlock()
+          _ <- Try(dataset.awaitUnlock())
         } yield (replacementId, replacementMeta)
     }.toList.collectResults.map(_.toMap)
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -149,6 +149,7 @@ class DatasetUpdater(deposit: Deposit,
           pathsToAdd = pathToFileInfo.keySet diff occupiedPaths
           filesToAdd = pathsToAdd.map(pathToFileInfo).toList
           _ = debug(s"filesToAdd = $filesToAdd")
+          _ <- Failure(new Exception("force a problem to test delete draft"))
           fileAdditions <- addFiles(doi, filesToAdd, prestagedFiles).map(_.mapValues(_.metadata))
 
           // TODO: check that only updating the file metadata works

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -22,9 +22,9 @@ import nl.knaw.dans.lib.dataverse.model.file.{ FileMeta => JavaFileMeta }
 import nl.knaw.dans.lib.dataverse.model.search
 import nl.knaw.dans.lib.error.{ TraversableTryExtensions, TryExtensions }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.scaladv.Version
 import nl.knaw.dans.lib.scaladv.model.dataset.MetadataBlocks
 import nl.knaw.dans.lib.scaladv.model.file.{ FileMeta => ScalaFileMeta }
-import nl.knaw.dans.lib.scaladv.{ DataverseInstance, Version }
 import org.json4s.native.Serialization
 
 import java.net.URI
@@ -42,7 +42,6 @@ class DatasetUpdater(deposit: Deposit,
                      metadataBlocks: MetadataBlocks,
                      variantToLicense: Map[String, String],
                      supportedLicenses: List[URI],
-                     dataverseInstance: DataverseInstance,
                      dataverseClient: DataverseClient,
                      optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
   trace(deposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -294,7 +294,8 @@ class DatasetUpdater(deposit: Deposit,
               fileApi.replaceWithPrestagedFile(prestagedFile.copy(forceReplace = true))
             }.getOrElse {
               debug(s"Uploading replacement file: $fileInfo")
-              fileApi.replace(Option(fileInfo.file), Option(ScalaFileMeta(forceReplace = true)))
+              val jsonStr = Serialization.writePretty(ScalaFileMeta(forceReplace = true))
+              fileApi.replaceFileItem(Option(fileInfo.file), Option(jsonStr))
             }
             fileList <- r.data
             id = fileList.files.head.dataFile.map(_.id).getOrElse(throw new IllegalStateException("Could not get ID of replacement file after replace action"))

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -41,7 +41,7 @@ class DatasetUpdater(deposit: Deposit,
                      supportedLicenses: List[URI],
                      dataverseInstance: DataverseInstance,
                      dataverseClient: DataverseClient,
-                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseInstance, dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
+                     optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(dataverseClient, optFileExclusionPattern, zipFileHandler) with DebugEnhancedLogging {
   trace(deposit)
 
   override def performEdit(): Try[PersistentId] = {
@@ -149,7 +149,6 @@ class DatasetUpdater(deposit: Deposit,
           pathsToAdd = pathToFileInfo.keySet diff occupiedPaths
           filesToAdd = pathsToAdd.map(pathToFileInfo).toList
           _ = debug(s"filesToAdd = $filesToAdd")
-          _ <- Failure(new Exception("force a problem to test delete draft"))
           fileAdditions <- addFiles(doi, filesToAdd, prestagedFiles).map(_.mapValues(_.metadata))
 
           // TODO: check that only updating the file metadata works

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -174,8 +174,9 @@ case class DepositIngestTask(deposit: Deposit,
 
   private def getDatasetContacts: Try[List[JsonObject]] = {
     for {
-      user <- Try(dataverseClient.admin().listSingleUser(deposit.depositorUserId).getData)
-      datasetContacts <- createDatasetContacts(user.getDisplayName, user.getEmail, Option(user.getAffiliation))
+      response <- dataverseInstance.admin().getSingleUser(deposit.depositorUserId)
+      user <- response.data
+      datasetContacts <- createDatasetContacts(user.displayName, user.email, user.affiliation)
     } yield datasetContacts
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -193,7 +193,7 @@ case class DepositIngestTask(deposit: Deposit,
   }
 
   protected def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {
-    new DatasetCreator(deposit, optFileExclusionPattern, zipFileHandler, depositorRole, isMigration = false, dataverseDataset, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, Option.empty)
+    new DatasetCreator(deposit, optFileExclusionPattern, zipFileHandler, depositorRole, isMigration = false, dataverseDataset, variantToLicense, supportedLicenses, dataverseClient, Option.empty)
   }
 
   protected def publishDataset(persistentId: String): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -189,7 +189,7 @@ case class DepositIngestTask(deposit: Deposit,
   }
 
   protected def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, Option.empty)
+    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseClient, Option.empty)
   }
 
   protected def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -79,7 +79,7 @@ class DepositMigrationTask(deposit: Deposit,
   }
 
   override def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, migrationInfo)
+    new DatasetUpdater(deposit, optFileExclusionPattern, zipFileHandler, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, variantToLicense, supportedLicenses, dataverseClient, migrationInfo)
   }
 
   override def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -83,7 +83,7 @@ class DepositMigrationTask(deposit: Deposit,
   }
 
   override def newDatasetCreator(dataverseDataset: Dataset, depositorRole: String): DatasetCreator = {
-    new DatasetCreator(deposit, optFileExclusionPattern, zipFileHandler, depositorRole, isMigration = true, dataverseDataset, variantToLicense, supportedLicenses, dataverseInstance, dataverseClient, migrationInfo)
+    new DatasetCreator(deposit, optFileExclusionPattern, zipFileHandler, depositorRole, isMigration = true, dataverseDataset, variantToLicense, supportedLicenses, dataverseClient, migrationInfo)
   }
 
   override protected def checkPersonalDataPresent(optAgreements: Option[Node]): Try[Unit] = {


### PR DESCRIPTION
Fixes DD-999: part 4 - replace dataverse library (scala to java)

# Description of changes

# How to test
As in https://github.com/DANS-KNAW/dd-ingest-flow/pull/20 but make sure 
* [x] one `<ddm:available>` is in the future
* [x] one `bag-info.txt` contains `Is-Version-Of: urn:uuid:...`
* [x] ~at least one of the files is a zip~

# Related PRs

* https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/26

# Notify

@DANS-KNAW/dataversedans
