### PR TITLE
DD-1011 Adapted call to validator for new interface of dd-validate-dans-bag

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -87,7 +87,7 @@ taskEventDatabase:
     hibernate.hbm2ddl.auto: update
 
 validateDansBag:
-  baseUrl: 'http://localhost:20180'
+  baseUrl: 'http://localhost:20330'
   connectionTimeoutMs: 10000
   readTimeoutMs: 30000
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -62,7 +62,7 @@ class DepositMigrationTask(deposit: Deposit,
     supportedLicenses,
     reportIdToTerm,
     outboxDir) {
-//  override protected val informationPackageType: InformationPackageType = InformationPackageType.AIP
+  override protected val informationPackageType: InformationPackageType = InformationPackageType.MIGRATION
 
   override protected def checkDepositType(): Try[Unit] = {
     for {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationCommand.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationCommand.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.dansbag
+
+import nl.knaw.dans.easy.dd2d.dansbag.InformationPackageType.InformationPackageType
+
+case class DansBagValidationCommand(bagLocation: String, packageType: InformationPackageType)
+
+
+

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationCommand.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationCommand.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.dd2d.dansbag
 
 import nl.knaw.dans.easy.dd2d.dansbag.InformationPackageType.InformationPackageType
 
-case class DansBagValidationCommand(bagLocation: String, packageType: InformationPackageType)
+case class DansBagValidationCommand(bagLocation: String, packageType: String)
 
 
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationResult.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidationResult.scala
@@ -34,12 +34,12 @@ import scala.util.{ Failure, Try }
  * @param ruleViolations  The rules that were violated. The violations are (rule number, violation
  *                        details) pairs. This field is absent if `isCompliant` is `true`.
  */
-case class DansBagValidationResult(bagUri: String,
-                                   bag: String,
-                                   infoPackageType: InformationPackageType.Value,
-                                   profileVersion: Int,
-                                   isCompliant: Boolean,
-                                   ruleViolations: Option[Seq[(String, String)]])
+case class DansBagValidationResult(`Bag location`: String,
+                                   Name: String,
+                                   `Information package type`: InformationPackageType.Value,
+                                   `Profile version`: String,
+                                   `Is compliant`: Boolean,
+                                   `Rule violations`: Seq[RuleViolation])
 object DansBagValidationResult {
   private implicit val jsonFormats: Formats = DefaultFormats +
     new EnumNameSerializer(InformationPackageType)
@@ -53,5 +53,5 @@ object DansBagValidationResult {
 
 object InformationPackageType extends Enumeration {
   type InformationPackageType = Value
-  val AIP, SIP = Value
+  val DEPOSIT, MIGRATION = Value
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/DansBagValidator.scala
@@ -47,11 +47,11 @@ class DansBagValidator(serviceUri: URI, connTimeoutMs: Int, readTimeoutMs: Int) 
     trace(bagDir)
     Try {
       val validationUri = serviceUri.resolve(s"validate")
-      val command = DansBagValidationCommand(bagLocation = bagDir.path.toString, informationPackageType)
-      logger.debug(s"Calling Dans Bag Validation Service with ${ validationUri.toASCIIString }")
+      val command = Serialization.write(DansBagValidationCommand(bagLocation = bagDir.path.toString, packageType = informationPackageType.toString))
+      logger.debug(s"Calling Dans Bag Validation Service with  command '$command'")
       Http(s"${ validationUri.toASCIIString }")
         .timeout(connTimeoutMs, readTimeoutMs)
-        .postMulti(MultiPart(data = Serialization.write(command), mime = "application/json", name = "command", filename = "command"))
+        .postMulti(MultiPart(data = command, mime = "application/json", name = "command", filename = "command"))
         .asString
     } flatMap {
       case r if r.code == 200 =>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/RuleViolation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/dansbag/RuleViolation.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.dansbag
+
+case class RuleViolation(rule: String, violation: String)


### PR DESCRIPTION
Fixes DD-1011

# Description of changes
* Added case classes to represent the command object to send to `dd-validate-dans-bag`.
* Changed the default URL of the validator service.


# Notify

@DANS-KNAW/dataversedans
