### PR TITLE
DD-1144 Input validation of startImport

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AbstractIngestArea {

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -43,8 +43,8 @@ public class ImportsResource {
     @POST
     @Path("/:start")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response startBatch(StartImport start) {
-        log.trace("Received command = {}", start);
+    public Response startImport(StartImport start) {
+        log.info("Received command = {}", start);
         String batchName;
         try {
             batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue(), false);

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -43,8 +43,8 @@ public class MigrationsResource {
     @POST
     @Path("/:start")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response startBatch(StartImport start) {
-        log.trace("Received command = {}", start);
+    public Response startImport(StartImport start) {
+        log.info("Received command = {}", start);
         String taskName;
         try {
             taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue(), true);


### PR DESCRIPTION
Fixes DD-1144

# Description of changes
When een import is started, the service now first checks whether input directory is a deposit (when isBatch = false) or a directory containing only deposits (when isBatch = true). This check is done synchronously, so that the client gets the result when the start call returns.

# Notify

@DANS-KNAW/dataversedans
