### PR TITLE
DD-921: block target after failed deposit

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
@@ -16,12 +16,12 @@
 package nl.knaw.dans.ingest.core;
 
 import nl.knaw.dans.ingest.core.legacy.DepositIngestTaskFactoryWrapper;
+import nl.knaw.dans.ingest.core.service.BlockedTargetService;
 import nl.knaw.dans.ingest.core.service.EnqueuingService;
 import nl.knaw.dans.ingest.core.service.TaskEventService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,13 +36,15 @@ public class AbstractIngestArea {
     protected final DepositIngestTaskFactoryWrapper taskFactory;
     protected final TaskEventService taskEventService;
     protected final EnqueuingService enqueuingService;
+    protected final BlockedTargetService blockedTargetService;
 
     public AbstractIngestArea(Path inboxDir, Path outboxDir,
-        DepositIngestTaskFactoryWrapper taskFactory, TaskEventService taskEventService, EnqueuingService enqueuingService) {
+        DepositIngestTaskFactoryWrapper taskFactory, TaskEventService taskEventService, BlockedTargetService blockedTargetService, EnqueuingService enqueuingService) {
         this.inboxDir = inboxDir.toAbsolutePath();
         this.outboxDir = outboxDir.toAbsolutePath();
         this.taskFactory = taskFactory;
         this.taskEventService = taskEventService;
+        this.blockedTargetService = blockedTargetService;
         this.enqueuingService = enqueuingService;
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/AutoIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AutoIngestArea.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.ingest.core;
 
 import io.dropwizard.lifecycle.Managed;
 import nl.knaw.dans.ingest.core.legacy.DepositIngestTaskFactoryWrapper;
+import nl.knaw.dans.ingest.core.service.BlockedTargetService;
 import nl.knaw.dans.ingest.core.service.UnboundedTargetedTaskSource;
 import nl.knaw.dans.ingest.core.service.EnqueuingService;
 import nl.knaw.dans.ingest.core.service.TaskEventService;
@@ -27,8 +28,8 @@ public class AutoIngestArea extends AbstractIngestArea implements Managed {
     private UnboundedTargetedTaskSource taskSource;
 
     public AutoIngestArea(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory,
-        TaskEventService taskEventService, EnqueuingService enqueuingService) {
-        super(inboxDir, outboxDir, taskFactory, taskEventService, enqueuingService);
+        TaskEventService taskEventService, BlockedTargetService blockedTargetService, EnqueuingService enqueuingService) {
+        super(inboxDir, outboxDir, taskFactory, taskEventService, blockedTargetService, enqueuingService);
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/ingest/core/BlockedTarget.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/BlockedTarget.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.ingest.core;
 
 import javax.persistence.Column;

--- a/src/main/java/nl/knaw/dans/ingest/core/BlockedTarget.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/BlockedTarget.java
@@ -1,0 +1,63 @@
+package nl.knaw.dans.ingest.core;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "blocked_target")
+
+public class BlockedTarget {
+    @Column(name = "deposit_id", nullable = false, length = 20)
+    private String depositId;
+
+    @Column(name = "target", nullable = false, length = 20)
+    private String target;
+
+    @Column(name = "state", nullable = false, length = 20)
+    private String state;
+
+    @Column(name = "message", nullable = false, length = 20)
+    private String message;
+
+    public BlockedTarget() {}
+
+    public BlockedTarget(String depositId, String target, String state, String message) {
+        this.depositId = depositId;
+        this.target = target;
+        this.state = state;
+        this.message = message;
+    }
+
+    public String getDepositId() {
+        return depositId;
+    }
+
+    public void setDepositId(String depositId) {
+        this.depositId = depositId;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.ingest.core;
 
 import nl.knaw.dans.ingest.core.legacy.DepositImportTaskWrapper;
 import nl.knaw.dans.ingest.core.legacy.DepositIngestTaskFactoryWrapper;
+import nl.knaw.dans.ingest.core.service.BlockedTargetService;
 import nl.knaw.dans.ingest.core.service.EnqueuingService;
 import nl.knaw.dans.ingest.core.service.SingleDepositTargetedTaskSourceImpl;
 import nl.knaw.dans.ingest.core.service.TargetedTaskSource;
@@ -41,8 +42,8 @@ public class ImportArea extends AbstractIngestArea {
     private final Map<String, TargetedTaskSource<DepositImportTaskWrapper>> batches = new HashMap<>();
 
     public ImportArea(Path inboxDir, Path outboxDir, DepositIngestTaskFactoryWrapper taskFactory, DepositIngestTaskFactoryWrapper migrationTaskFactory,
-        TaskEventService taskEventService, EnqueuingService enqueuingService) {
-        super(inboxDir, outboxDir, taskFactory, taskEventService, enqueuingService);
+        TaskEventService taskEventService, BlockedTargetService blockedTargetService, EnqueuingService enqueuingService) {
+        super(inboxDir, outboxDir, taskFactory, taskEventService, blockedTargetService, enqueuingService);
         this.migrationTaskFactory = migrationTaskFactory;
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/BlockedTargetService.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/BlockedTargetService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+import nl.knaw.dans.ingest.core.TaskEvent;
+
+import java.util.UUID;
+
+public interface BlockedTargetService {
+
+    void writeBlocekdTarget(String depositId, String target, String state, String message);
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/service/BlockedTargetServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/BlockedTargetServiceImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import nl.knaw.dans.ingest.core.BlockedTarget;
+import nl.knaw.dans.ingest.core.TaskEvent;
+import nl.knaw.dans.ingest.db.BlockedTargetDAO;
+import nl.knaw.dans.ingest.db.TaskEventDAO;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class BlockedTargetServiceImpl implements BlockedTargetService {
+    private final BlockedTargetDAO blockedTargetDAO;
+
+    public BlockedTargetServiceImpl(BlockedTargetDAO blockedTargetDAO) {
+        this.blockedTargetDAO = blockedTargetDAO;
+    }
+
+    @Override
+    @UnitOfWork
+    public void writeBlocekdTarget(String depositId, String target, String state, String message) {
+        blockedTargetDAO.save(new BlockedTarget(depositId, target, state, message));
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/db/BlockedTargetDAO.java
+++ b/src/main/java/nl/knaw/dans/ingest/db/BlockedTargetDAO.java
@@ -1,0 +1,42 @@
+package nl.knaw.dans.ingest.db;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import nl.knaw.dans.ingest.core.BlockedTarget;
+import nl.knaw.dans.ingest.core.TaskEvent;
+import org.hibernate.SessionFactory;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.LinkedList;
+import java.util.List;
+
+public class BlockedTargetDAO extends AbstractDAO<BlockedTarget> {
+    public BlockedTargetDAO(SessionFactory sessionFactory) {
+        super(sessionFactory);
+    }
+
+
+    public BlockedTarget save(BlockedTarget blockedTarget) {
+        return persist(blockedTarget);
+    }
+
+    public List<BlockedTarget> getTarget(String target, String depositId) {
+        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaQuery<BlockedTarget> crit = cb.createQuery(BlockedTarget.class);
+        Root<BlockedTarget> r = crit.from(BlockedTarget.class);
+        List<Predicate> predicates = new LinkedList<>();
+        if (target != null) {
+            predicates.add(cb.equal(r.get("target"), target));
+        }
+        if (depositId != null) {
+            predicates.add(cb.equal(r.get("depositId"), depositId));
+        }
+        crit
+            .select(r)
+            .where(cb.and(predicates.toArray(new Predicate[0])));
+
+        return currentSession().createQuery(crit).list();
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/db/BlockedTargetDAO.java
+++ b/src/main/java/nl/knaw/dans/ingest/db/BlockedTargetDAO.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.ingest.db;
 
 import io.dropwizard.hibernate.AbstractDAO;

--- a/src/main/java/nl/knaw/dans/ingest/resources/BlockedTargetResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/BlockedTargetResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.resources;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import nl.knaw.dans.ingest.core.BlockedTarget;
+import nl.knaw.dans.ingest.db.BlockedTargetDAO;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import java.util.List;
+
+@Path("/events")
+public class BlockedTargetResource {
+
+    private final BlockedTargetDAO BlockedTargetDAO;
+
+    public BlockedTargetResource(BlockedTargetDAO taskEventDAO) {
+        this.BlockedTargetDAO = taskEventDAO;
+    }
+
+    @GET
+    @Produces("text/csv;charset=utf8")
+    @UnitOfWork
+    public List<BlockedTarget> getTarget(@QueryParam("source") String target, @QueryParam("depositId") String depositId) {
+        return BlockedTargetDAO.getTarget(target, depositId);
+    }
+
+}


### PR DESCRIPTION
Fixes block target after failed deposit

# Description of changes
Work in progress.

* [x] added tables and resources
* [ ] check blocked target before starting a task
* [ ] add blocked target on failure of a task

Confused about resources per table and a configuration that suggest a database for the originally single table. I suppose task events is shared among various processes and block-target is only used by the main process (dd-ingest-flow).

https://github.com/DANS-KNAW/dd-ingest-flow/blob/d7204a717db68c400036fa66d508dc5724130918/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java#L139-L140

https://github.com/DANS-KNAW/dd-ingest-flow/blob/c3faafd589f7b9bccf6f71203ef0bc881de7d8a2/src/main/java/nl/knaw/dans/ingest/DdIngestFlowConfiguration.java#L74

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
