### PR TITLE
DD-1131 Metadata character encoding problems on test_ssh migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>dans-dropwizard-project</artifactId>
         <groupId>nl.knaw.dans.shared</groupId>
-        <version>9.4.0</version>
+        <version>9.5.0</version>
     </parent>
 
     <groupId>nl.knaw.dans</groupId>
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
Fixes DD-1131

# Description of changes
Upgraded parent pom, and in doing so `dans-dataverse-client-lib`

# Related PRs

* [ Metadata character encoding problems on test_ssh migration](https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/33)

# Notify

@DANS-KNAW/dataversedans
