### PR TITLE
DD-1199: health check - dropped too early readEntity

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidatorImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidatorImpl.java
@@ -46,8 +46,7 @@ public class DansBagValidatorImpl implements DansBagValidator {
     public void checkConnection() {
         try (var response = httpClient.target(pingUri)
             .request(MediaType.TEXT_PLAIN)
-            .get()
-            .readEntity(Response.class)) {
+            .get()) {
 
             if (response.getStatus() != 200) {
                 var content = response.readEntity(String.class);


### PR DESCRIPTION
Fixes DD-

# Description of changes

readEntity was read twice causing the service to report unhealty

# How to test
https://dans-knaw.github.io/dd-ingest-flow/dev/

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
