### PR TITLE
Dd 1210

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -93,6 +93,21 @@ validateDansBag:
   connectionTimeoutMs: 10000
   readTimeoutMs: 30000
 
+# this configures the bag validator client
+# the important thing is to disable chunked encoding
+# because it breaks the multipart/form-data headers
+dansBagValidatorClient:
+  timeout: 30000ms
+  connectionTimeout: 10000ms
+  chunkedEncodingEnabled: false
+  timeToLive: 1h
+  cookiesEnabled: false
+  maxConnections: 128
+  maxConnectionsPerRoute: 128
+  keepAlive: 0ms
+  retries: 0
+  userAgent: dd-ingest-flow
+
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging
 #

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
@@ -256,6 +256,8 @@ public class DepositToDvDatasetMetadataMapper {
         block.setDisplayName(displayName);
         block.setFields(result);
 
+        // TODO add de-duplication here
+
         fields.put(title, block);
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
@@ -256,8 +256,6 @@ public class DepositToDvDatasetMetadataMapper {
         block.setDisplayName(displayName);
         block.setFields(result);
 
-        // TODO add de-duplication here
-
         fields.put(title, block);
     }
 


### PR DESCRIPTION
Fixes DD-1210

# Description of changes

For some reason, enabling chunked encoding on a HTTP client breaks multipart/form-data messages because it does not include a boundary in the headers. So this chunk configuration needs to be set to disabled in order for form-data to work.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
