### PR TITLE
Dd 1209

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class AbstractDepositsImportTaskIterator implements Iterator<DepositIngestTask> {
@@ -41,11 +43,9 @@ public abstract class AbstractDepositsImportTaskIterator implements Iterator<Dep
         this.eventWriter = eventWriter;
     }
 
-    protected boolean readAllDepositsFromInbox() {
-        try (Stream<Path> paths = Files.list(inboxDir)) {
-            paths.map(d -> taskFactory.createIngestTask(d, outBox, eventWriter))
-                .sorted().forEach(deque::add);
-            return !deque.isEmpty();
+    protected List<Path> readAllDepositsFromInbox() {
+        try (Stream<Path> paths = Files.list(inboxDir).filter(Files::isDirectory)) {
+            return paths.collect(Collectors.toList());
         }
         catch (IOException e) {
             throw new IllegalStateException("Could not read deposits from inbox", e);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactory.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactory.java
@@ -149,7 +149,6 @@ public class DepositIngestTaskFactory {
     public DepositIngestTask createIngestTask(Path depositDir, Path outboxDir, EventWriter eventWriter) {
         try {
             var deposit = depositManager.loadDeposit(depositDir);
-            //        var deposit = new Deposit(better.files.File.apply(depositDir));
             return createDepositIngestTask(deposit, outboxDir, eventWriter);
         }
         catch (InvalidDepositException | IOException e) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
@@ -256,6 +256,8 @@ public class DepositToDvDatasetMetadataMapper {
         block.setDisplayName(displayName);
         block.setFields(result);
 
+        // TODO add de-duplication here
+
         fields.put(title, block);
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositToDvDatasetMetadataMapper.java
@@ -256,8 +256,6 @@ public class DepositToDvDatasetMetadataMapper {
         block.setDisplayName(displayName);
         block.setFields(result);
 
-        // TODO add de-duplication here
-
         fields.put(title, block);
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/EnqueuingServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/EnqueuingServiceImpl.java
@@ -44,7 +44,8 @@ public class EnqueuingServiceImpl implements EnqueuingService {
                 for (T t : source) {
                     enqueue(t);
                 }
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 log.error("Enqueuing could not start because of an error", e);
             }
         });


### PR DESCRIPTION
Fixes DD-

# Description of changes

Fixes the way deposits are read after the initial pass in the auto ingest areas. Previously due to logic, if a deposit existed it would skip the first new deposit after that. 

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
