### PR TITLE
Ddm v2

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
@@ -44,9 +44,11 @@ public abstract class AbstractDepositsImportTaskIterator implements Iterator<Dep
         this.eventWriter = eventWriter;
     }
 
-    protected List<Path> readAllDepositsFromInbox() {
+    protected List<Path> getAllDepositPathsFromInbox() {
         try (Stream<Path> paths = Files.list(inboxDir).filter(Files::isDirectory)) {
-            return paths.collect(Collectors.toList());
+            var pathList = paths.collect(Collectors.toList());
+            log.debug("Found {} deposits", pathList.size());
+            return pathList;
         }
         catch (IOException e) {
             throw new IllegalStateException("Could not read deposits from inbox", e);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/BoundedDepositImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/BoundedDepositImportTaskIterator.java
@@ -21,6 +21,8 @@ public class BoundedDepositImportTaskIterator extends  AbstractDepositsImportTas
     public BoundedDepositImportTaskIterator(Path inboxDir, Path outBox, DepositIngestTaskFactory taskFactory,
         EventWriter eventWriter) {
         super(inboxDir, outBox, taskFactory, eventWriter);
-        readAllDepositsFromInbox();
+        for(var p: getAllDepositPathsFromInbox()) {
+            addTaskForDeposit(p);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
@@ -131,7 +131,7 @@ public abstract class DatasetEditor {
     }
 
     protected String getLicense(Node node) {
-        return XPathEvaluator.nodes(node, "//ddm:dcmiMetadata/dcterms:license")
+        return XPathEvaluator.nodes(node, "/ddm:DDM/ddm:dcmiMetadata/dcterms:license")
             .filter(License::isLicenseUri)
             .findFirst()
             .map(n -> License.getLicenseUri(supportedLicenses, variantToLicense, n))
@@ -210,7 +210,7 @@ public abstract class DatasetEditor {
     }
 
     Instant getDateAvailable(Deposit deposit) {
-        return XPathEvaluator.strings(deposit.getDdm(), "//ddm:profile/ddm:available")
+        return XPathEvaluator.strings(deposit.getDdm(), "/ddm:DDM/ddm:profile/ddm:available")
             .map(DatasetEditor::parseDate)
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Deposit without a ddm:available element"));
@@ -222,7 +222,7 @@ public abstract class DatasetEditor {
         var ddm = deposit.getDdm();
         var files = deposit.getFilesXml();
 
-        var accessRights = XPathEvaluator.nodes(ddm, "//ddm:profile/ddm:accessRights")
+        var accessRights = XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/ddm:accessRights")
             .findFirst()
             .orElseThrow();
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
@@ -131,7 +131,10 @@ public class DepositMigrationTask extends DepositIngestTask {
 
             var dataset = dataverseClient.dataset(persistentId);
 
-            dataset.releaseMigrated(date.get(), true);
+
+            var datePublishJsonLd = String.format("{\"http://schema.org/datePublished\": \"%s\"}", date.get());
+
+            dataset.releaseMigrated(datePublishJsonLd, true);
             dataset.awaitUnlock(publishAwaitUnlockMaxNumberOfRetries, publishAwaitUnlockMillisecondsBetweenRetries);
         }
         catch (IOException | DataverseException e) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
@@ -114,32 +114,28 @@ public class DepositMigrationTask extends DepositIngestTask {
     }
 
     @Override
-    void publishDataset(String persistentId) throws Exception {
-        try {
-            var deposit = getDeposit();
-            var amd = deposit.getAmd();
+    void publishDataset(String persistentId) throws IOException, DataverseException {
 
-            if (amd == null) {
-                throw new Exception(String.format("no AMD found for %s", persistentId));
-            }
+        var deposit = getDeposit();
+        var amd = deposit.getAmd();
 
-            var date = Amd.toPublicationDate(amd);
-
-            if (date.isEmpty()) {
-                throw new IllegalArgumentException(String.format("no publication date found in AMD for %s", persistentId));
-            }
-
-            var dataset = dataverseClient.dataset(persistentId);
-
-
-            var datePublishJsonLd = String.format("{\"http://schema.org/datePublished\": \"%s\"}", date.get());
-
-            dataset.releaseMigrated(datePublishJsonLd, true);
-            dataset.awaitUnlock(publishAwaitUnlockMaxNumberOfRetries, publishAwaitUnlockMillisecondsBetweenRetries);
+        if (amd == null) {
+            throw new RuntimeException(String.format("no AMD found for %s", persistentId));
         }
-        catch (IOException | DataverseException e) {
-            log.error("Unable to publish dataset", e);
+
+        var date = Amd.toPublicationDate(amd);
+
+        if (date.isEmpty()) {
+            throw new IllegalArgumentException(String.format("no publication date found in AMD for %s", persistentId));
         }
+
+        var dataset = dataverseClient.dataset(persistentId);
+
+        var datePublishJsonLd = String.format("{\"http://schema.org/datePublished\": \"%s\"}", date.get());
+
+        dataset.releaseMigrated(datePublishJsonLd, true);
+        dataset.awaitUnlock(publishAwaitUnlockMaxNumberOfRetries, publishAwaitUnlockMillisecondsBetweenRetries);
+
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/ingest/core/service/UnboundedDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/UnboundedDepositsImportTaskIterator.java
@@ -78,7 +78,7 @@ public class UnboundedDepositsImportTaskIterator extends AbstractDepositsImportT
             initialized = true;
 
             // find all deposits
-            var initialDeposits = readAllDepositsFromInbox();
+            var initialDeposits = getAllDepositPathsFromInbox();
 
             for (var path : initialDeposits) {
                 log.trace("onStart initial deposit found: {}", path);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/XPathEvaluator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/XPathEvaluator.java
@@ -29,21 +29,7 @@ import java.util.Iterator;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-public final class XPathEvaluator {
-
-    public static final String NAMESPACE_XML = "http://www.w3.org/XML/1998/namespace";
-    public static final String NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";
-    public static final String NAMESPACE_DCX_DAI = "http://easy.dans.knaw.nl/schemas/dcx/dai/";
-    public static final String NAMESPACE_DDM = "http://easy.dans.knaw.nl/schemas/md/ddm/";
-    public static final String NAMESPACE_DCTERMS = "http://purl.org/dc/terms/";
-    public static final String NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance";
-    public static final String NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/";
-    public static final String NAMESPACE_DCX_GML = "http://easy.dans.knaw.nl/schemas/dcx/gml/";
-    public static final String NAMESPACE_FILES_XML = "http://easy.dans.knaw.nl/schemas/bag/metadata/files/";
-    public static final String NAMESPACE_OPEN_GIS = "http://www.opengis.net/gml";
-    public static final String NAMESPACE_EASY_WORKFLOW = "http://easy.dans.knaw.nl/easy/workflow/";
-    public static final String NAMESPACE_DAMD = "http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/";
-    public static final String NAMESPACE_AGREEMENTS = "http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/";
+public final class XPathEvaluator implements XmlNamespaces {
 
     private static XPath xpath;
 
@@ -54,19 +40,19 @@ public final class XPathEvaluator {
                 .newXPath();
 
             final var namespaceMap = new HashMap<String, String>();
-            namespaceMap.put("xml", NAMESPACE_XML);
-            namespaceMap.put("dc", NAMESPACE_DC);
-            namespaceMap.put("dcx-dai", NAMESPACE_DCX_DAI);
-            namespaceMap.put("ddm", NAMESPACE_DDM);
-            namespaceMap.put("dcterms", NAMESPACE_DCTERMS);
-            namespaceMap.put("xsi", NAMESPACE_XSI);
-            namespaceMap.put("id-type", NAMESPACE_ID_TYPE);
-            namespaceMap.put("dcx-gml", NAMESPACE_DCX_GML);
-            namespaceMap.put("files", NAMESPACE_FILES_XML);
-            namespaceMap.put("gml", NAMESPACE_OPEN_GIS);
-            namespaceMap.put("wfs", NAMESPACE_EASY_WORKFLOW);
-            namespaceMap.put("damd", NAMESPACE_DAMD);
-            namespaceMap.put("agreements", NAMESPACE_AGREEMENTS);
+            namespaceMap.put("xml", XmlNamespaces.NAMESPACE_XML);
+            namespaceMap.put("dc", XmlNamespaces.NAMESPACE_DC);
+            namespaceMap.put("dcx-dai", XmlNamespaces.NAMESPACE_DCX_DAI);
+            namespaceMap.put("ddm", XmlNamespaces.NAMESPACE_DDM);
+            namespaceMap.put("dcterms", XmlNamespaces.NAMESPACE_DCTERMS);
+            namespaceMap.put("xsi", XmlNamespaces.NAMESPACE_XSI);
+            namespaceMap.put("id-type", XmlNamespaces.NAMESPACE_ID_TYPE);
+            namespaceMap.put("dcx-gml", XmlNamespaces.NAMESPACE_DCX_GML);
+            namespaceMap.put("files", XmlNamespaces.NAMESPACE_FILES_XML);
+            namespaceMap.put("gml", XmlNamespaces.NAMESPACE_OPEN_GIS);
+            namespaceMap.put("wfs", XmlNamespaces.NAMESPACE_EASY_WORKFLOW);
+            namespaceMap.put("damd", XmlNamespaces.NAMESPACE_DAMD);
+            namespaceMap.put("agreements", XmlNamespaces.NAMESPACE_AGREEMENTS);
 
             xpath.setNamespaceContext(new NamespaceContext() {
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/XmlNamespaces.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/XmlNamespaces.java
@@ -19,9 +19,7 @@ public interface XmlNamespaces {
     String NAMESPACE_XML = "http://www.w3.org/XML/1998/namespace";
     String NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";
     String NAMESPACE_DCX_DAI = "http://easy.dans.knaw.nl/schemas/dcx/dai/";
-//    String NAMESPACE_DDM = "http://schemas.dans.knaw.nl/dataset/ddm/";
-
-    String NAMESPACE_DDM = "http://easy.dans.knaw.nl/schemas/md/ddm/";
+    String NAMESPACE_DDM = "http://schemas.dans.knaw.nl/dataset/ddm-v2/";
     String NAMESPACE_DCTERMS = "http://purl.org/dc/terms/";
     String NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance";
     String NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/";

--- a/src/main/java/nl/knaw/dans/ingest/core/service/XmlNamespaces.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/XmlNamespaces.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+public interface XmlNamespaces {
+    String NAMESPACE_XML = "http://www.w3.org/XML/1998/namespace";
+    String NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";
+    String NAMESPACE_DCX_DAI = "http://easy.dans.knaw.nl/schemas/dcx/dai/";
+//    String NAMESPACE_DDM = "http://schemas.dans.knaw.nl/dataset/ddm/";
+
+    String NAMESPACE_DDM = "http://easy.dans.knaw.nl/schemas/md/ddm/";
+    String NAMESPACE_DCTERMS = "http://purl.org/dc/terms/";
+    String NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance";
+    String NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/";
+    String NAMESPACE_DCX_GML = "http://easy.dans.knaw.nl/schemas/dcx/gml/";
+    String NAMESPACE_FILES_XML = "http://easy.dans.knaw.nl/schemas/bag/metadata/files/";
+    String NAMESPACE_OPEN_GIS = "http://www.opengis.net/gml";
+    String NAMESPACE_EASY_WORKFLOW = "http://easy.dans.knaw.nl/easy/workflow/";
+    String NAMESPACE_DAMD = "http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/";
+    String NAMESPACE_AGREEMENTS = "http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/";
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/service/XmlReader.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/XmlReader.java
@@ -22,18 +22,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public interface XmlReader {
-
-    String NAMESPACE_XML = "http://www.w3.org/XML/1998/namespace";
-    String NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";
-    String NAMESPACE_DCX_DAI = "http://easy.dans.knaw.nl/schemas/dcx/dai/";
-    String NAMESPACE_DDM = "http://easy.dans.knaw.nl/schemas/md/ddm/";
-    String NAMESPACE_DCTERMS = "http://purl.org/dc/terms/";
-    String NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance";
-    String NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/";
-    String NAMESPACE_DCX_GML = "http://easy.dans.knaw.nl/schemas/dcx/gml/";
-    String NAMESPACE_FILES_XML = "http://easy.dans.knaw.nl/schemas/bag/metadata/files/";
-    String NAMESPACE_OPEN_GIS = "http://www.opengis.net/gml";
+public interface XmlReader extends XmlNamespaces {
 
     Document readXmlFile(Path path) throws ParserConfigurationException, IOException, SAXException;
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -291,31 +291,31 @@ public class DepositToDvDatasetMetadataMapper {
     }
 
     Stream<Node> getDescriptions(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:profile/dcterms:description | //ddm:profile/dc:description");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/dcterms:description | /ddm:DDM/ddm:profile/dc:description");
     }
 
     Stream<Node> getMetadataDescriptions(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:description");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:description");
     }
 
     Stream<Node> getTemporal(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/ddm:temporal");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/ddm:temporal");
     }
 
     Stream<Node> getSpatial(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:spatial");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:spatial");
     }
 
     Stream<Node> getBoundedBy(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:spatial//gml:boundedBy");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:spatial//gml:boundedBy");
     }
 
     Stream<Node> getSubjects(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:subject");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:subject");
     }
 
     Stream<Node> getLanguages(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:language");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:language");
     }
 
     Stream<Node> getAcquisitionMethods(Document ddm) {
@@ -329,92 +329,92 @@ public class DepositToDvDatasetMetadataMapper {
 
     Stream<Node> getReportNumbers(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/ddm:reportNumber");
+            "/ddm:DDM/ddm:dcmiMetadata/ddm:reportNumber");
     }
 
     Stream<Node> getRelations(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata//*");
+            "/ddm:DDM/ddm:dcmiMetadata//*");
     }
 
     Stream<Node> getInCollections(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/ddm:inCollection");
+            "/ddm:DDM/ddm:dcmiMetadata/ddm:inCollection");
     }
 
     Stream<String> getLanguageAttributes(Document ddm) {
-        return XPathEvaluator.strings(ddm, "//ddm:profile//@xml:lang | //ddm:dcmiMetadata//@xml:lang");
+        return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:profile//@xml:lang | /ddm:DDM/ddm:dcmiMetadata//@xml:lang");
     }
 
     Stream<Node> getContributorDetailsOrganizations(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:organization");
+            "/ddm:DDM/ddm:dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:organization");
     }
 
     Stream<Node> getContributorDetailsAuthors(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:author");
+            "/ddm:DDM/ddm:dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:author");
     }
 
     Stream<Node> getContributorDetails(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcx-dai:contributorDetails[dcx-dai:author] | //ddm:dcmiMetadata/dcx-dai:contributorDetails[dcx-dai:organization]");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcx-dai:contributorDetails[dcx-dai:author] | /ddm:DDM/ddm:dcmiMetadata/dcx-dai:contributorDetails[dcx-dai:organization]");
     }
 
     Stream<Node> getCreated(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:profile/ddm:created");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/ddm:created");
     }
 
     Stream<String> getAudiences(Document ddm) {
-        return XPathEvaluator.strings(ddm, "//ddm:profile/ddm:audience");
+        return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:profile/ddm:audience");
     }
 
     Stream<Node> getIdentifiers(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:identifier");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:identifier");
     }
 
     Stream<String> getTitles(Document ddm) {
-        return XPathEvaluator.strings(ddm, "//ddm:profile/dc:title");
+        return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:profile/dc:title");
     }
 
     Stream<Node> getAlternativeTitles(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/dcterms:title", "//ddm:dcmiMetadata/dcterms:alternative");
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:title", "/ddm:DDM/ddm:dcmiMetadata/dcterms:alternative");
     }
 
     Stream<Node> getCreators(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:profile/dcx-dai:creatorDetails | //ddm:profile/dcx-dai:creator | //ddm:profile/dc:creator");
+            "/ddm:DDM/ddm:profile/dcx-dai:creatorDetails | /ddm:DDM/ddm:profile/dcx-dai:creator | /ddm:DDM/ddm:profile/dc:creator");
     }
 
     Stream<Node> getOtherDescriptions(Document ddm) {
         return XPathEvaluator.nodes(ddm,
-            "//ddm:dcmiMetadata/dcterms:date",
-            "//ddm:dcmiMetadata/dcterms:dateAccepted",
-            "//ddm:dcmiMetadata/dcterms:dateCopyrighted",
-            "//ddm:dcmiMetadata/dcterms:modified",
-            "//ddm:dcmiMetadata/dcterms:issued",
-            "//ddm:dcmiMetadata/dcterms:valid",
-            "//ddm:dcmiMetadata/dcterms:coverage");
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:date",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:dateAccepted",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:dateCopyrighted",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:modified",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:issued",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:valid",
+            "/ddm:DDM/ddm:dcmiMetadata/dcterms:coverage");
     }
 
     Stream<Node> getPublishers(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/dcterms:publisher");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:publisher");
     }
 
     Stream<Node> getAvailable(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:profile/ddm:available");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/ddm:available");
     }
 
     Stream<Node> getDatesOfCollection(Document ddm) {
-        return XPathEvaluator.nodes(ddm, "//ddm:dcmiMetadata/ddm:datesOfCollection");
+        return XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:dcmiMetadata/ddm:datesOfCollection");
     }
 
     Stream<String> getDataSources(Document ddm) {
-        return XPathEvaluator.strings(ddm, "//ddm:dcmiMetadata/dcterms:source");
+        return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:source");
     }
 
     Stream<String> getRightsHolders(Document ddm) {
-        return XPathEvaluator.strings(ddm, "//ddm:dcmiMetadata/dcterms:rightsHolder");
+        return XPathEvaluator.strings(ddm, "/ddm:DDM/ddm:dcmiMetadata/dcterms:rightsHolder");
     }
 
     void checkRequiredField(String fieldName, Stream<String> nodes) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -320,7 +320,7 @@ public class DepositToDvDatasetMetadataMapper {
 
     Stream<Node> getAcquisitionMethods(Document ddm) {
         var expr = String.format(
-            "//ddm:dcmiMetadata/ddm:acquisitionMethod[@subjectScheme = '%s' and @schemeURI = '%s']",
+            "/ddm:DDM/ddm:dcmiMetadata/ddm:acquisitionMethod[@subjectScheme = '%s' and @schemeURI = '%s']",
             SCHEME_ABR_VERWERVINGSWIJZE, SCHEME_URI_ABR_VERWERVINGSWIJZE
         );
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiAuthor.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiAuthor.java
@@ -80,7 +80,7 @@ public final class DcxDaiAuthor extends Base {
         }
         if (StringUtils.isNotBlank(author.getRole())) {
             var value = contributorRoleToContributorType.getOrDefault(author.getRole(), "Other");
-            builder.addSubfield(CONTRIBUTOR_TYPE, value);
+            builder.addControlledSubfield(CONTRIBUTOR_TYPE, value);
         }
     };
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
@@ -179,7 +179,7 @@ public class FileElement extends Base {
     }
 
     public static Map<Path, FileInfo> pathToFileInfo(Deposit deposit) {
-        var defaultRestrict = XPathEvaluator.nodes(deposit.getDdm(), "//ddm:profile/ddm:accessRights")
+        var defaultRestrict = XPathEvaluator.nodes(deposit.getDdm(), "/ddm:DDM/ddm:profile/ddm:accessRights")
             .map(AccessRights::toDefaultRestrict)
             .findFirst()
             .orElse(true);

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
@@ -89,11 +89,10 @@ class MappingIntegrationTest {
     @Test
     void DD_1216_description_type_other_maps_only_to_author_name() throws Exception {
         var doc = readDocumentFromString(
-            "<ddm:DDM xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:DDM xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
             + "         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n"
-            + "         xmlns:dct=\"http://purl.org/dc/terms/\"\n"
-            + "         xsi:schemaLocation=\"http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd\">\n"
+            + "         xmlns:dct=\"http://purl.org/dc/terms/\">\n"
             + ddmProfile
             + "    <ddm:dcmiMetadata>\n"
             + "        <dct:rightsHolder>Mr. Rights</dct:rightsHolder>\n"
@@ -116,11 +115,10 @@ class MappingIntegrationTest {
     @Test
     void DD_1216_description_type_technical_info_maps_once_to_description() throws Exception {
         var doc = readDocumentFromString(
-            "<ddm:DDM xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:DDM xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
                 + "         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\n"
-                + "         xmlns:dct=\"http://purl.org/dc/terms/\"\n"
-                + "         xsi:schemaLocation=\"http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd\">\n"
+                + "         xmlns:dct=\"http://purl.org/dc/terms/\">\n"
                 + ddmProfile
                 + "    <ddm:dcmiMetadata>\n"
                 + "        <dct:rightsHolder>Mr. Rights</dct:rightsHolder>\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AbrReportTypeTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AbrReportTypeTest.java
@@ -27,7 +27,7 @@ class AbrReportTypeTest extends BaseTest {
     @Test
     void isAbrReportType_should_return_true_when_properties_match() throws Exception {
         var doc = readDocumentFromString("<ddm:reportNumber \n"
-            + "            xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            + "            xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "            subjectScheme=\"ABR Rapporten\" \n"
             + "            schemeURI=\"https://data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e\">value</ddm:reportNumber>");
 
@@ -37,7 +37,7 @@ class AbrReportTypeTest extends BaseTest {
     @Test
     void isAbrReportType_should_return_false_when_subjectScheme_does_not_match() throws Exception {
         var doc = readDocumentFromString("<ddm:reportNumber \n"
-            + "            xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            + "            xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "            subjectScheme=\"INVALID\" \n"
             + "            schemeURI=\"https://data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e\">value</ddm:reportNumber>");
 
@@ -47,7 +47,7 @@ class AbrReportTypeTest extends BaseTest {
     @Test
     void isAbrReportType_should_return_false_when_schemeURI_does_not_match() throws Exception {
         var doc = readDocumentFromString("<ddm:reportNumber \n"
-            + "            xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            + "            xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "            subjectScheme=\"ABR Rapporten\" \n"
             + "            schemeURI=\"https://fake.data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e\">value</ddm:reportNumber>");
 
@@ -58,7 +58,7 @@ class AbrReportTypeTest extends BaseTest {
     void toAbrRapportType_should_return_valueURI() throws Exception {
         var doc = readDocumentFromString(
             "<ddm:reportNumber \n"
-                + "            xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "            xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "            subjectScheme=\"ABR Rapporten\" \n"
                 + "            valueURI=\"https://dar.dans.knaw.nl/\" \n"
                 + "            schemeURI=\"https://data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e\" />");
@@ -70,7 +70,7 @@ class AbrReportTypeTest extends BaseTest {
     void toAbrRapportType_should_return_null_when_valueURI_is_missing() throws Exception {
         var doc = readDocumentFromString(
             "<ddm:reportNumber \n"
-                + "            xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "            xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "            subjectScheme=\"ABR Rapporten\" \n"
                 + "            schemeURI=\"https://data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e\" />");
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AccessRightsTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AccessRightsTest.java
@@ -25,7 +25,7 @@ class AccessRightsTest extends BaseTest {
     @Test
     void toDefaultRestrict_should_return_false_when_access_rights_is_OPEN_ACCESS() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  OPEN_ACCESS"
             + "</ddm:accessRights>\n");
 
@@ -35,7 +35,7 @@ class AccessRightsTest extends BaseTest {
     @Test
     void toDefaultRestrict_should_return_true_when_access_rights_is_OPEN_ACCESS_FOR_REGISTERED_USERS() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  OPEN_ACCESS_FOR_REGISTERED_USERS"
             + "</ddm:accessRights>\n");
 
@@ -45,7 +45,7 @@ class AccessRightsTest extends BaseTest {
     @Test
     void toDefaultRestrict_should_return_true_when_access_rights_is_REQUEST_PERMISSION() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  REQUEST_PERMISSION"
             + "</ddm:accessRights>\n");
 
@@ -55,7 +55,7 @@ class AccessRightsTest extends BaseTest {
     @Test
     void toDefaultRestrict_should_return_true_when_access_rights_is_NO_ACCESS() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  NO_ACCESS"
             + "</ddm:accessRights>\n");
 
@@ -65,7 +65,7 @@ class AccessRightsTest extends BaseTest {
     @Test
     void toDefaultRestrict_should_return_true_when_access_rights_is_something_else() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  SOMETHING"
             + "</ddm:accessRights>\n");
 
@@ -75,13 +75,13 @@ class AccessRightsTest extends BaseTest {
     @Test
     void isEnableRequests_should_be_false_if_one_file_has_explicitly_accessibleTo_equals_NONE() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  OPEN_ACCESS"
             + "</ddm:accessRights>\n");
 
         var files = readDocumentFromString("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
             + "<files xmlns=\"http://easy.dans.knaw.nl/schemas/bag/metadata/files/\" \n"
-            + "        xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    <file filepath=\"data/leeg.txt\">\n"
             + "        <ddm:accessibleToRights>ANONYMOUS</ddm:accessibleToRights>\n"
             + "    </file>\n"
@@ -99,13 +99,13 @@ class AccessRightsTest extends BaseTest {
     @Test
     void isEnableRequests_should_be_false_if_one_file_has_implicitly_accessibleTo_equals_NONE() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  NO_ACCESS"
             + "</ddm:accessRights>\n");
 
         var files = readDocumentFromString("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
             + "<files xmlns=\"http://easy.dans.knaw.nl/schemas/bag/metadata/files/\" \n"
-            + "        xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    <file filepath=\"data/leeg.txt\">\n"
             + "    </file>\n"
             + "    <file filepath=\"data/sub/leeg2.txt\">\n"
@@ -119,13 +119,13 @@ class AccessRightsTest extends BaseTest {
     @Test
     void isEnableRequests_should_be_true_if_all_files_explicitly_permission_request() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  NO_ACCESS"
             + "</ddm:accessRights>\n");
 
         var files = readDocumentFromString("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
             + "<files xmlns=\"http://easy.dans.knaw.nl/schemas/bag/metadata/files/\" \n"
-            + "        xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    <file filepath=\"data/leeg.txt\">\n"
             + "        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>\n"
             + "    </file>\n"
@@ -140,13 +140,13 @@ class AccessRightsTest extends BaseTest {
     @Test
     void isEnableRequests_should_be_true_if_all_implicitly_and_explicitly_defined_accessibleTo_is_RESTRICTED_REQUEST_or_more_open() throws Exception {
         var doc = readDocumentFromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<ddm:accessRights xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "<ddm:accessRights xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "  REQUEST_PERMISSION"
             + "</ddm:accessRights>\n");
 
         var files = readDocumentFromString("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
             + "<files xmlns=\"http://easy.dans.knaw.nl/schemas/bag/metadata/files/\" \n"
-            + "        xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+            + "        xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    <file filepath=\"data/leeg.txt\">\n"
             + "        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>\n"
             + "    </file>\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DatesOfCollectionTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DatesOfCollectionTest.java
@@ -26,7 +26,7 @@ class DatesOfCollectionTest extends BaseTest {
 
     @Test
     void toDateOfCollectionValue_should_split_correctly_formatted_date_range_in_start_and_end_subfields() throws Exception {
-        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    2022-01-01/2022-02-01\n"
             + "</ddm:datesOfCollection>\n");
 
@@ -47,7 +47,7 @@ class DatesOfCollectionTest extends BaseTest {
 
     @Test
     void toDateOfCollectionValue_should_handle_ranges_without_start() throws Exception {
-        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    /2022-02-01\n"
             + "</ddm:datesOfCollection>\n");
 
@@ -68,7 +68,7 @@ class DatesOfCollectionTest extends BaseTest {
 
     @Test
     void toDateOfCollectionValue_should_handle_ranges_without_end() throws Exception {
-        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\">\n"
+        var doc = readDocumentFromString("<ddm:datesOfCollection xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\">\n"
             + "    2022-01-01/   \n"
             + "</ddm:datesOfCollection>\n");
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/PersonalStatementTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/PersonalStatementTest.java
@@ -65,7 +65,7 @@ class PersonalStatementTest extends BaseTest {
 
     @Test
     void test_with_agreements_xml() throws Exception {
-        var doc = xmlReader.readXmlString("<agreements xsi:schemaLocation=\"http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/ https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/agreements.xsd\"\n"
+        var doc = xmlReader.readXmlString("<agreements\n"
             + "            xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
             + "            xmlns:dcterms=\"http://purl.org/dc/terms/\"\n"
             + "            xmlns=\"http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/\"\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
@@ -32,10 +32,9 @@ class RelationTest extends BaseTest {
     void test_to_relation_object() throws Exception {
 
         var doc = readDocumentFromString(
-            "<ddm:DDM xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:DDM xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-                + "         xmlns:dct=\"http://purl.org/dc/terms/\"\n"
-                + "         xsi:schemaLocation=\"http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd\">\n"
+                + "         xmlns:dct=\"http://purl.org/dc/terms/\">\n"
                 + "    <ddm:dcmiMetadata>\n"
                 + "        <dct:license xsi:type=\"dct:URI\">http://creativecommons.org/licenses/by-sa/4.0</dct:license>\n"
                 + "        <dct:rightsHolder>Mr. Rights</dct:rightsHolder>\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
@@ -44,7 +44,7 @@ class RelationTest extends BaseTest {
                 + "</ddm:DDM>\n");
 
         var builder = new CompoundFieldBuilder("", true);
-        XPathEvaluator.nodes(doc, "//ddm:dcmiMetadata//*")
+        XPathEvaluator.nodes(doc, "/ddm:DDM/ddm:dcmiMetadata//*")
             .filter(Relation::isRelation)
             .forEach(item -> {
                 Relation.toRelationObject.build(builder, item);

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SubjectAbrTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SubjectAbrTest.java
@@ -33,7 +33,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isOldAbr_should_return_true_if_schemeURI_of_old_ABR_is_used_and_subjectScheme_matches_name() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -49,7 +49,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isOldAbr_should_return_false_if_schemeURI_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -65,7 +65,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isOldAbr_should_return_false_if_subjectScheme_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -85,7 +85,7 @@ class SubjectAbrTest extends BaseTest {
         var valueUri = "https://data.cultureelerfgoed.nl/term/id/rn/" + termUuid;
 
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"%s\"\n"
@@ -105,7 +105,7 @@ class SubjectAbrTest extends BaseTest {
         var valueUri = "https://data.cultureelerfgoed.nl/term/id/rn/" + termUuid;
 
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"%s\"\n"
@@ -121,7 +121,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrArtifact_should_return_true_for_subject_element_matching_schemeURI_and_subjectScheme_attributes() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -137,7 +137,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrArtifact_should_return_false_for_wrong_schemeURI() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -153,7 +153,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrArtifact_should_return_false_for_wrong_subjectScheme() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -169,7 +169,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrComplex_should_return_true_for_subject_element_matching_schemeURI_and_subjectScheme_attributes() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -185,7 +185,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrComplex_should_return_false_for_wrong_schemeURI() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -201,7 +201,7 @@ class SubjectAbrTest extends BaseTest {
     @Test
     void isAbrComplex_should_return_false_for_wrong_subjectScheme() throws Exception {
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"https://test4.com/supersecret/\"\n"
@@ -221,7 +221,7 @@ class SubjectAbrTest extends BaseTest {
         var valueUri = "https://data.cultureelerfgoed.nl/term/id/rn/" + termUuid;
 
         var doc = readDocumentFromString(String.format(
-            "<ddm:subject xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            "<ddm:subject xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    schemeURI=\"%s\"\n"
                 + "    subjectScheme=\"%s\"\n"
                 + "    valueURI=\"%s\"\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SubjectTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SubjectTest.java
@@ -30,7 +30,7 @@ class SubjectTest extends BaseTest {
     @Test
     void hasNoCvAttributes_should_return_false_for_ABR_subjects() throws Exception {
         var doc = readDocumentFromString("<ddm:subject xml:lang=\"nl\" \n"
-            + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
             + "    subjectScheme=\"ABR Complextypen\" \n"
             + "    schemeURI=\"https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0\">\n"
@@ -43,7 +43,7 @@ class SubjectTest extends BaseTest {
     @Test
     void hasNoCvAttributes_should_return_true_for_a_subject_with_no_subjectScheme_and_schemeURI_attributes() throws Exception {
         var doc = readDocumentFromString("<ddm:subject xml:lang=\"nl\" \n"
-            + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+            + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
             + "    >\n"
             + "    bewoning (inclusief verdediging)\n"
             + "</ddm:subject>");
@@ -55,7 +55,7 @@ class SubjectTest extends BaseTest {
     void isPanTerm_should_return_true_if_both_schemeURI_and_subjectScheme_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"
@@ -69,7 +69,7 @@ class SubjectTest extends BaseTest {
     void isPanTerm_should_return_false_if_schemeURI_does_not_match_for_pan() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"
@@ -83,7 +83,7 @@ class SubjectTest extends BaseTest {
     void isPanTerm_should_return_false_if_subjectScheme_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"
@@ -97,7 +97,7 @@ class SubjectTest extends BaseTest {
     void isAatTerm_should_return_true_if_both_schemeURI_and_subjectScheme_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"
@@ -111,7 +111,7 @@ class SubjectTest extends BaseTest {
     void isAatTerm_should_return_false_if_schemeURI_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"
@@ -125,7 +125,7 @@ class SubjectTest extends BaseTest {
     void isAatTerm_should_return_false_if_subjectScheme_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "<ddm:subject xml:lang=\"nl\" \n"
-                + "    xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "    xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "    valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/2179d872-888f-4807-a6d5-5e5afaa616c4\" \n"
                 + "    subjectScheme=\"%s\" \n"
                 + "    schemeURI=\"%s\">\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/TemporalAbrTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/TemporalAbrTest.java
@@ -31,7 +31,7 @@ class TemporalAbrTest extends BaseTest {
     void isAbrPeriod_should_return_true_if_schemeURI_subjectScheme_for_ABR_Periods_is_used() throws Exception {
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -44,7 +44,7 @@ class TemporalAbrTest extends BaseTest {
     void isAbrPeriod_should_return_false_if_schemeURI_does_not_match() throws Exception {
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -58,7 +58,7 @@ class TemporalAbrTest extends BaseTest {
 
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -72,7 +72,7 @@ class TemporalAbrTest extends BaseTest {
 
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -86,7 +86,7 @@ class TemporalAbrTest extends BaseTest {
 
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -100,7 +100,7 @@ class TemporalAbrTest extends BaseTest {
 
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"
@@ -113,7 +113,7 @@ class TemporalAbrTest extends BaseTest {
     void toAbrPeriod_should_create_correct_value_object() throws Exception {
         var doc = readDocumentFromString(String.format(
             "    <ddm:temporal\n"
-                + "      xmlns:ddm=\"http://easy.dans.knaw.nl/schemas/md/ddm/\"\n"
+                + "      xmlns:ddm=\"http://schemas.dans.knaw.nl/dataset/ddm-v2/\"\n"
                 + "      schemeURI=\"%s\"\n"
                 + "      subjectScheme=\"%s\"\n"
                 + "      valueURI=\"https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d\" xml:lang=\"nl\">Nieuwe Tijd</ddm:temporal>\n"

--- a/src/test/resources/xml/abrs.xml
+++ b/src/test/resources/xml/abrs.xml
@@ -1,6 +1,4 @@
-<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd">
+<ddm:DDM xmlns:ddm="http://schemas.dans.knaw.nl/dataset/ddm-v2/">
     <ddm:dcmiMetadata>
         <ddm:subject>no tags subject</ddm:subject>
         <ddm:subject schemeURI="https://data.cultureelerfgoed.nl/term/id/pan/PAN"

--- a/src/test/resources/xml/dataset.xml
+++ b/src/test/resources/xml/dataset.xml
@@ -1,4 +1,4 @@
-<ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+<ddm:DDM xmlns:ddm="http://schemas.dans.knaw.nl/dataset/ddm-v2/"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:dct="http://purl.org/dc/terms/"


### PR DESCRIPTION
NO JIRA 

# Description of changes
* Made XPath expression stricter if possible (so not starting with `//` if it is known exactly what the path to the element must be starting from the documentElement).
* Fixed setting the publication date for migrated datasets, restoring the JSON LD doc that must surround the date in the `releaseMigrated` call.
* Deduplicated the definition of the XML namespace URIs by putting them in an interface that is inherited by both `XPathEvaluator` and `XmlReader`.
* Changed DDM namespace to DDM v2 namespace.
* Removed `xsi:schemaLocation` attributes from XML documents, as it is ignored/overruled.
* Fixed problem with silently failing if publication step fails.
* Fixed erroneous subfield type in Contributor field.

# Notify

@DANS-KNAW/dataversedans
