### PR TITLE
Rethrow exception

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -274,7 +274,6 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     }
 
     void publishDataset(String persistentId) throws Exception {
-
         try {
             var dataset = dataverseClient.dataset(persistentId);
 
@@ -283,6 +282,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
         }
         catch (IOException | DataverseException e) {
             log.error("Unable to publish dataset", e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
Fixes DD-1238

# Description of changes

In a single case, when an exception during publishing of a dataset, it would only log the error but not propagate the error. The code would assume everything went OK despite the publishing having failed. 

All other catch clauses have also been checked for swallowing errors, but no other cases could be identified that were not by design.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
