### PR TITLE
Rename refactorings + zipwrapping for replaceFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
@@ -76,8 +76,7 @@ public class DatasetCreator extends DatasetEditor {
             return persistentId;
         }
         catch (Exception e) {
-            log.error("Error creating dataset", e);
-            throw new FailedDepositException(deposit, "could not import/create dataset", e);
+            throw new FailedDepositException(deposit, "Error creating dataset, deleting draft", e);
         }
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -30,6 +30,7 @@ import nl.knaw.dans.lib.dataverse.model.search.DatasetResultItem;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
@@ -91,18 +92,18 @@ public class DatasetUpdater extends DatasetEditor {
 
                 var pathToFileInfo = getFileInfo();
                 log.debug("pathToFileInfo = {}", pathToFileInfo);
-                var pathToFileInfoInLatestVersion = getFilesInfoInLatestVersion(api);
+                var pathToFileMetaInLatestVersion = getFilesInfoInLatestVersion(api);
 
-                validateFileMetas(pathToFileInfoInLatestVersion);
+                validateFileMetas(pathToFileMetaInLatestVersion);
 
                 var versions = api.getAllVersions().getData();
                 var publishedVersions = versions.stream().filter(v -> v.getVersionState().equals("RELEASED")).count();
                 log.debug("Number of published versions so far: {}", publishedVersions);
 
                 // move old paths to new paths
-                var oldToNewPathMovedFiles = getOldToNewPathOfFilesToMove(pathToFileInfoInLatestVersion, pathToFileInfo);
+                var oldToNewPathMovedFiles = getOldToNewPathOfFilesToMove(pathToFileMetaInLatestVersion, pathToFileInfo);
                 var fileMovements = oldToNewPathMovedFiles.keySet().stream()
-                    .map(path -> Map.entry(pathToFileInfoInLatestVersion.get(path).getDataFile().getId(), pathToFileInfo.get(path).getMetadata()))
+                    .map(path -> Map.entry(pathToFileMetaInLatestVersion.get(path).getDataFile().getId(), pathToFileInfo.get(path).getMetadata()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 log.debug("fileMovements = {}", fileMovements);
 
@@ -115,12 +116,13 @@ public class DatasetUpdater extends DatasetEditor {
                  *
                  * - trying to add a file with a name that already exists. This happens when a file A is renamed to B, while B is also part of the latest version
                  */
-                var fileReplacementCandidates = pathToFileInfoInLatestVersion.entrySet().stream()
-                    .filter(k -> !oldToNewPathMovedFiles.containsKey(k.getKey()))
-                    .filter(k -> !oldToNewPathMovedFiles.containsValue(k.getKey())) // TODO in the OG version, this was a Set; check what performance is like
+                var fileReplacementCandidates = pathToFileMetaInLatestVersion.entrySet().stream()
+                    .filter(pathToFileInfoEntry -> !oldToNewPathMovedFiles.containsKey(pathToFileInfoEntry.getKey()))
+                    .filter(pathToFileInfoEntry -> !oldToNewPathMovedFiles.containsValue(pathToFileInfoEntry.getKey())) // TODO in the OG version, this was a Set; check what performance is like
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 var filesToReplace = getFilesToReplace(pathToFileInfo, fileReplacementCandidates);
+                log.debug("filesToReplace = {}", filesToReplace);
                 var fileReplacements = replaceFiles(api, filesToReplace);
                 log.debug("fileReplacements = {}", fileReplacements);
 
@@ -138,10 +140,10 @@ public class DatasetUpdater extends DatasetEditor {
                  * This may be a bit confusing, but the goals is to make sure that the underlying FILE remains present (after all, it is to be renamed/moved). The
                  * path itself WILL be "removed" from the latest version by the move. (It MAY be filled again by a file addition in the same update, though.)
                  */
-                var pathsToDelete = diff(diff(pathToFileInfoInLatestVersion.keySet(), candidateRemainingFiles), oldToNewPathMovedSet);
+                var pathsToDelete = diff(diff(pathToFileMetaInLatestVersion.keySet(), candidateRemainingFiles), oldToNewPathMovedSet);
                 log.debug("pathsToDelete = {}", pathsToDelete);
 
-                var fileDeletions = getFileDeletions(pathsToDelete, pathToFileInfoInLatestVersion);
+                var fileDeletions = getFileDeletions(pathsToDelete, pathToFileMetaInLatestVersion);
                 log.debug("fileDeletions = {}", fileDeletions);
 
                 deleteFiles(api, fileDeletions);
@@ -161,7 +163,7 @@ public class DatasetUpdater extends DatasetEditor {
                  * All paths in the deposit that are not occupied, are new files to be added.
                  */
 
-                var diffed = diff(diff(pathToFileInfoInLatestVersion.keySet(), oldToNewPathMovedSet), pathsToDelete);
+                var diffed = diff(diff(pathToFileMetaInLatestVersion.keySet(), oldToNewPathMovedSet), pathsToDelete);
                 var occupiedPaths = union(diffed, oldToNewPathMovedFiles.values());
 
                 log.debug("occupiedPaths = {}", occupiedPaths);
@@ -274,15 +276,29 @@ public class DatasetUpdater extends DatasetEditor {
         var results = new HashMap<Integer, FileMeta>();
 
         for (var entry : filesToReplace.entrySet()) {
+            log.debug("Replacing file with ID = {}", entry.getKey());
             var fileApi = dataverseClient.file(entry.getKey());
 
             var meta = new FileMeta();
             meta.setForceReplace(true);
             var json = objectMapper.writeValueAsString(meta);
+            var wrappedZip = zipFileHandler.wrapIfZipFile(entry.getValue().getPath());
+            var file = wrappedZip.orElse(entry.getValue().getPath());
+
+            log.debug("Calling replaceFileItem({}, {})", entry.getValue().getPath(), json);
             var result = fileApi.replaceFileItem(
-                Optional.of(entry.getValue().getPath().toFile()),
+                Optional.of(file.toFile()),
                 Optional.of(json)
             );
+
+            if (wrappedZip.isPresent()) {
+                try {
+                    Files.deleteIfExists(wrappedZip.get());
+                }
+                catch (IOException e) {
+                    log.error("Unable to delete zipfile {}", wrappedZip.get(), e);
+                }
+            }
 
             var id = -1;
 
@@ -336,7 +352,7 @@ public class DatasetUpdater extends DatasetEditor {
         var checksumsToPathNonDuplicatedFilesInDeposit = getChecksumsToPathOfNonDuplicateFiles(depositChecksums);
         var checksumsToPathNonDuplicatedFilesInLatestVersion = getChecksumsToPathOfNonDuplicateFiles(latestFileChecksums);
 
-        var intersects = checksumsToPathNonDuplicatedFilesInLatestVersion.keySet().stream()
+        var intersects = checksumsToPathNonDuplicatedFilesInDeposit.keySet().stream()
             .filter(checksumsToPathNonDuplicatedFilesInLatestVersion::containsKey)
             .collect(Collectors.toSet());
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -182,7 +182,7 @@ public class DatasetUpdater extends DatasetEditor {
                 var fileIdsToEmbargo = union(fileReplacements.keySet(), fileAdditions.keySet())
                     .stream()
                     .map(key -> Map.entry(key, fileReplacements.getOrDefault(key, fileAdditions.get(key))))
-                    .filter(entry -> !"easy-migration".equals(entry.getValue().getDirectoryLabel()))
+                    .filter(entry -> !"easy-migration.zip".equals(entry.getValue().getLabel()))
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toSet());
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -272,6 +272,7 @@ public class DepositToDvDatasetMetadataMapper {
         processMetadataBlock(deduplicate, fields, "dansDataVaultMetadata", "Dans Vault Metadata", dataVaultFieldBuilder);
 
         var version = new DatasetVersion();
+        version.setTermsOfAccess("N/a"); // TODO: retrieve from input
         version.setMetadataBlocks(fields);
         version.setFiles(new ArrayList<>());
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
@@ -59,7 +59,7 @@ public class FileElement extends Base {
         var dirPath = Optional.ofNullable(pathInDataset.getParent()).map(Path::toString).orElse(null);
         var sanitizedDirLabel = replaceForbiddenCharactersInPath(dirPath);
 
-        var restricted = getChildNode(node, "dcterms:accessibleToRights")
+        var restricted = getChildNode(node, "files:accessibleToRights")
             .map(Node::getTextContent)
             .map(accessibilityToRestrict::get)
             .orElse(defaultRestrict);


### PR DESCRIPTION
NO JIRA

# Description of changes
Several fixes:

* Upgraded to dans-dataverse-client-lib 0.12.0 for support for restrict(ed) property. Corrected ns in lookup of accessibleToRights and added default accessTerms (for now)
* More flexible parsing of available dates. Fix for excluding easy-migration.zip from embargo in updates
* Rename refactorings + zipwrapping for replaceFile
* Replace java.time.format.DateTimeFormatter with SimpleDateFormat for converting embargo Instant back to date string. DateTimeFormatter resulted in unsuppoert field 'YearOfEra'
* hsqldb back to v2.5.0 (temporarily)



# Notify

@DANS-KNAW/dataversedans
