### PR TITLE
DD-1249  Sort deposits on Created timestamp when reading all from inbox

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -27,4 +27,5 @@ mkdir -p $TEMPDIR/import/inbox
 mkdir -p $TEMPDIR/import/outbox
 mkdir -p $TEMPDIR/auto-ingest/inbox
 mkdir -p $TEMPDIR/auto-ingest/outbox
+mkdir -p $TEMPDIR/tmp
 echo "OK"

--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowConfiguration.java
@@ -30,13 +30,19 @@ import javax.validation.constraints.NotNull;
 
 public class DdIngestFlowConfiguration extends Configuration {
 
+    @NotNull
     private IngestFlowConfig ingestFlow;
 
+    @NotNull
     private DataverseClientFactory dataverse;
 
+    @NotNull
     private DataverseExtra dataverseExtra;
 
+    @NotNull
     private ValidateDansBagConfig validateDansBag;
+
+    @NotNull
     private DataSourceFactory taskEventDatabase;
 
     @Valid

--- a/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
@@ -79,6 +79,9 @@ public abstract class AbstractDepositsImportTaskIterator implements Iterator<Dep
     }
 
     protected void addTask(DepositIngestTask task) {
+        if (log.isDebugEnabled()) {
+            log.debug("Adding task for {}", task.getDeposit().getDir().getFileName());
+        }
         deque.add(task);
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/AbstractDepositsImportTaskIterator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.stream.Collectors;
@@ -55,15 +56,32 @@ public abstract class AbstractDepositsImportTaskIterator implements Iterator<Dep
         }
     }
 
+    protected List<DepositIngestTask> createDepositIngestTasks(List<Path> depositPaths) {
+        var tasks = new LinkedList<DepositIngestTask>();
+        for (var p : depositPaths) {
+            try {
+                tasks.add(taskFactory.createIngestTask(p, outBox, eventWriter));
+            }
+            catch (InvalidDepositException | IOException e) {
+                throw new IllegalArgumentException("Could not create task for deposit", e);
+            }
+        }
+        return tasks.stream().sorted().collect(Collectors.toList());
+    }
+
     protected void addTaskForDeposit(Path dir) {
         try {
-            var task = taskFactory.createIngestTask(dir, outBox, eventWriter);
-            deque.add(task);
+            addTask(taskFactory.createIngestTask(dir, outBox, eventWriter));
         }
         catch (IOException | InvalidDepositException e) {
             log.error("Error while creating task", e);
         }
     }
+
+    protected void addTask(DepositIngestTask task) {
+        deque.add(task);
+    }
+
 
     @Override
     public boolean hasNext() {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/BoundedDepositImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/BoundedDepositImportTaskIterator.java
@@ -15,14 +15,18 @@
  */
 package nl.knaw.dans.ingest.core.service;
 
-import java.nio.file.Path;
+import nl.knaw.dans.ingest.core.service.exception.InvalidDepositException;
 
-public class BoundedDepositImportTaskIterator extends  AbstractDepositsImportTaskIterator {
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+
+public class BoundedDepositImportTaskIterator extends AbstractDepositsImportTaskIterator {
     public BoundedDepositImportTaskIterator(Path inboxDir, Path outBox, DepositIngestTaskFactory taskFactory,
         EventWriter eventWriter) {
         super(inboxDir, outBox, taskFactory, eventWriter);
-        for(var p: getAllDepositPathsFromInbox()) {
-            addTaskForDeposit(p);
-        }
+        createDepositIngestTasks(getAllDepositPathsFromInbox()).forEach(this::addTask);
     }
+
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/UnboundedDepositsImportTaskIterator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/UnboundedDepositsImportTaskIterator.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class UnboundedDepositsImportTaskIterator extends AbstractDepositsImportTaskIterator {
     private static final Logger log = LoggerFactory.getLogger(UnboundedDepositsImportTaskIterator.class);
@@ -78,12 +79,13 @@ public class UnboundedDepositsImportTaskIterator extends AbstractDepositsImportT
             initialized = true;
 
             // find all deposits
-            var initialDeposits = getAllDepositPathsFromInbox();
+            var initialTasks = createDepositIngestTasks(getAllDepositPathsFromInbox());
 
-            for (var path : initialDeposits) {
-                log.trace("onStart initial deposit found: {}", path);
+            for (var task : initialTasks) {
+                var path = task.getDeposit().getDir();
+                log.debug("onStart initial deposit found: {}", path);
                 initialPathsRead.add(path);
-                addTaskForDeposit(path);
+                addTask(task);
             }
 
             log.trace("onStart finished");

--- a/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
@@ -94,7 +94,6 @@ public class DepositStartImportTaskWrapperTest {
         );
 
         return task;
-//        return new DepositIngestTask(task, eventWriter);
     }
 
     @BeforeEach

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -58,6 +58,11 @@ dataverse:
   #  connectionTimeoutMs: 10000
   #  readTimeoutMs: 30000
 
+dataverseExtra:
+  publishAwaitUnlockMaxRetries: 900
+  publishAwaitUnlockWaitTimeMs: 3000
+
+
 taskEventDatabase:
   driverClass: org.hsqldb.jdbcDriver
   url: jdbc:hsqldb:hsql://localhost:9001/dd-ingest-flow


### PR DESCRIPTION
Fixes DD-1249

# Description of changes
* When initially filling the queue sort tasks on Created timestamp before adding them to the queue.
* Faulty config will fail fast now, because of `@NonNull` annotations.

# Notify

@DANS-KNAW/dataversedans
