### PR TITLE
Refactored away unnecessary boolean 'isMigration'

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
@@ -134,15 +134,14 @@ public class DdIngestFlowApplication extends Application<DdIngestFlowConfigurati
             configuration.getIngestFlow().getImportConfig().getInbox(),
             configuration.getIngestFlow().getImportConfig().getOutbox(),
             ingestTaskFactory,
-            migrationTaskFactory, // Only necessary during migration. Can be phased out after that.
             taskEventService,
             enqueuingService);
 
+        // Only necessary during migration. Can be phased out after that.
         final ImportArea migrationArea = new ImportArea(
             configuration.getIngestFlow().getMigration().getInbox(),
             configuration.getIngestFlow().getMigration().getOutbox(),
-            ingestTaskFactory,
-            migrationTaskFactory, // Only necessary during migration. Can be phased out after that.
+            migrationTaskFactory,
             taskEventService,
             enqueuingService);
 

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -47,7 +47,7 @@ public class ImportsResource {
         log.info("Received command = {}", start);
         String batchName;
         try {
-            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue(), false);
+            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -47,7 +47,7 @@ public class MigrationsResource {
         log.info("Received command = {}", start);
         String taskName;
         try {
-            taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue(), true);
+            taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());


### PR DESCRIPTION
NO JIRA

# Description of changes
The `ImportArea` class is used for both "bulk imports" and "migrations". It is instantiated twice during application initialization: 1) as `importArea` and as `migrationArea`. In both cases it was given two task factories: one for bulk import tasks and one for migration tasks. Since each of the areas is dedicated to only one type of task it would only ever use one of those factories. 

Refactored this, so that `ImportArea` receives only one factory; `nl.knaw.dans.ingest.DdIngestFlowApplication#run` makes sure it is the correct one. The resource classes now don't have to pass the `isMigration` parameter anymore.

Also remove a `batches` map that was updated but never read.

# How to test


*

# Notify

@DANS-KNAW/dataversedans
