### PR TITLE
DD-1216 last: dct:accessRights to description or termsofaccess

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -338,7 +338,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
         var contact = getDatasetContact();
         var deposit = getDeposit();
         var accessibleToValues = XPathEvaluator
-            .strings(deposit.getFilesXml(), "//files:accessibleToRights")
+            .strings(deposit.getFilesXml(), "/files:files/files:file/files:accessibleToRights")
             .collect(Collectors.toList());
         var hasRestrictedOrNoneFiles = accessibleToValues.contains("RESTRICTED_REQUEST") || accessibleToValues.contains("NONE");
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -337,6 +337,10 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
         var date = getDateOfDeposit();
         var contact = getDatasetContact();
         var deposit = getDeposit();
+        var accessibleToValues = XPathEvaluator
+            .strings(deposit.getFilesXml(), "//files:file/ddm:accessibleToRights")
+            .collect(Collectors.toList());
+        var hasRestrictedOrNoneFiles = accessibleToValues.contains("RESTRICTED_REQUEST") || accessibleToValues.contains("NONE");
 
         // TODO think about putting assertions inside a getter method
         checkPersonalDataPresent(deposit.getAgreements());
@@ -349,8 +353,8 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
             deposit.getAgreements(),
             date.orElse(null),
             contact.orElse(null),
-            deposit.getVaultMetadata()
-        );
+            deposit.getVaultMetadata(),
+            hasRestrictedOrNoneFiles);
     }
 
     void checkPersonalDataPresent(Document agreements) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -338,7 +338,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
         var contact = getDatasetContact();
         var deposit = getDeposit();
         var accessibleToValues = XPathEvaluator
-            .strings(deposit.getFilesXml(), "//accessibleToRights")
+            .strings(deposit.getFilesXml(), "//files:accessibleToRights")
             .collect(Collectors.toList());
         var hasRestrictedOrNoneFiles = accessibleToValues.contains("RESTRICTED_REQUEST") || accessibleToValues.contains("NONE");
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -338,7 +338,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
         var contact = getDatasetContact();
         var deposit = getDeposit();
         var accessibleToValues = XPathEvaluator
-            .strings(deposit.getFilesXml(), "//files:file/ddm:accessibleToRights")
+            .strings(deposit.getFilesXml(), "//accessibleToRights")
             .collect(Collectors.toList());
         var hasRestrictedOrNoneFiles = accessibleToValues.contains("RESTRICTED_REQUEST") || accessibleToValues.contains("NONE");
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
@@ -19,10 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.knaw.dans.ingest.core.service.VaultMetadata;
 import nl.knaw.dans.ingest.core.service.XmlReader;
 import nl.knaw.dans.ingest.core.service.XmlReaderImpl;
-import nl.knaw.dans.ingest.core.service.mapper.DepositToDvDatasetMetadataMapper;
 import nl.knaw.dans.ingest.core.service.mapper.builder.ArchaeologyFieldBuilder;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -83,7 +81,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", "otherId:something", "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata);
+        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()
@@ -97,7 +95,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", "doi:a/b", "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata);
+        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()
@@ -113,7 +111,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", null, "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata);
+        var result = mapper.toDataverseDataset(doc, null, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()


### PR DESCRIPTION
dct:accessRights (to description part)

Fixes DD-1216 last: dct:accessRights to description or termsofaccess

# Description of changes

# How to test

See https://dans-knaw.github.io/dd-ingest-flow/dev

* [x]  dct:accessRights is placed in a description 
* [x] when files are restricted it is placed in tab terms, field Terms of Access for Restricted Files


# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
