### PR TITLE
DD-1171: add SHA1 manifest if not present

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/Deposit.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/Deposit.java
@@ -15,7 +15,14 @@
  */
 package nl.knaw.dans.ingest.core.service;
 
+import gov.loc.repository.bagit.creator.CreatePayloadManifestsVistor;
 import gov.loc.repository.bagit.domain.Bag;
+import gov.loc.repository.bagit.domain.Manifest;
+import gov.loc.repository.bagit.hash.Hasher;
+import gov.loc.repository.bagit.hash.StandardSupportedAlgorithms;
+import gov.loc.repository.bagit.hash.SupportedAlgorithm;
+import gov.loc.repository.bagit.util.PathUtils;
+import gov.loc.repository.bagit.writer.ManifestWriter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,9 +30,20 @@ import nl.knaw.dans.ingest.core.DepositState;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static gov.loc.repository.bagit.hash.StandardSupportedAlgorithms.SHA1;
 
 @Data
 @NoArgsConstructor
@@ -114,5 +132,4 @@ public class Deposit {
     public Path getAmdPath() {
         return bagDir.resolve("metadata/amd.xml");
     }
-
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.ingest.core.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.knaw.dans.validatedansbag.api.ValidateCommand;
 import nl.knaw.dans.ingest.core.DepositState;
 import nl.knaw.dans.ingest.core.TaskEvent;
 import nl.knaw.dans.ingest.core.sequencing.TargetedTask;
@@ -30,6 +29,7 @@ import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
+import nl.knaw.dans.validatedansbag.api.ValidateCommand;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,6 +221,13 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
                     "Bag was not valid according to Profile Version %s. Violations: %s",
                     result.getProfileVersion(), violations)
                 );
+            } else {
+                try {
+                    ManifestHelper.addSha1File(deposit.getBag());
+                } catch (Exception e){
+                    log.error("could not add SHA1 manifest", e);
+                    throw new FailedDepositException(deposit, e.getMessage());
+                }
             }
         }
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+import gov.loc.repository.bagit.creator.CreatePayloadManifestsVistor;
+import gov.loc.repository.bagit.domain.Bag;
+import gov.loc.repository.bagit.domain.Manifest;
+import gov.loc.repository.bagit.hash.Hasher;
+import gov.loc.repository.bagit.hash.StandardSupportedAlgorithms;
+import gov.loc.repository.bagit.util.PathUtils;
+import gov.loc.repository.bagit.writer.ManifestWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static gov.loc.repository.bagit.hash.StandardSupportedAlgorithms.SHA1;
+
+public class ManifestHelper {
+
+    static public void addSha1File(Bag bag) throws NoSuchAlgorithmException, IOException {
+        var manifests = bag.getPayLoadManifests();
+        var algorithms = manifests.stream().map(Manifest::getAlgorithm);
+        if (algorithms.anyMatch(SHA1::equals))
+            return;
+
+        var payloadFilesMap = Hasher.createManifestToMessageDigestMap(List.of(SHA1));
+        var payloadVisitor = new CreatePayloadManifestsVistor(payloadFilesMap, true);
+        Files.walkFileTree(PathUtils.getDataDir(bag), payloadVisitor);
+        manifests.addAll(payloadFilesMap.keySet());
+        ManifestWriter.writePayloadManifests(manifests, PathUtils.getBagitDir(bag), bag.getRootDir(), bag.getFileEncoding());
+    }
+
+    static public Map<Path, String> getFilePathToSha1(Deposit deposit) {
+        var result = new HashMap<Path, String>();
+        var bag = deposit.getBag();
+        var manifest = bag.getPayLoadManifests().stream()
+            .filter(item -> item.getAlgorithm().equals(StandardSupportedAlgorithms.SHA1))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Deposit bag does not have SHA-1 payload manifest"));
+
+        for (var entry : manifest.getFileToChecksumMap().entrySet()) {
+            result.put(deposit.getBagDir().relativize(entry.getKey()), entry.getValue());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
@@ -85,16 +85,15 @@ public class ManifestHelper {
         ManifestWriter.writeTagManifests(bag.getTagManifests(), PathUtils.getBagitDir(bag), bagRootDir, bag.getFileEncoding());
     }
 
-    static public Map<Path, String> getFilePathToSha1(Deposit deposit) {
+    static public Map<Path, String> getFilePathToSha1(Bag bag) {
         var result = new HashMap<Path, String>();
-        var bag = deposit.getBag();
         var manifest = bag.getPayLoadManifests().stream()
             .filter(item -> item.getAlgorithm().equals(StandardSupportedAlgorithms.SHA1))
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Deposit bag does not have SHA-1 payload manifest"));
 
         for (var entry : manifest.getFileToChecksumMap().entrySet()) {
-            result.put(deposit.getBagDir().relativize(entry.getKey()), entry.getValue());
+            result.put(bag.getRootDir().relativize(entry.getKey()), entry.getValue());
         }
 
         return result;

--- a/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/ManifestHelper.java
@@ -39,7 +39,7 @@ import static gov.loc.repository.bagit.hash.StandardSupportedAlgorithms.SHA1;
 
 public class ManifestHelper {
 
-    static public void addSha1File(Bag bag) throws NoSuchAlgorithmException, IOException {
+    static public void ensureSha1ManifestPresent(Bag bag) throws NoSuchAlgorithmException, IOException {
         var manifests = bag.getPayLoadManifests();
         var algorithms = manifests.stream().map(Manifest::getAlgorithm);
         if (algorithms.anyMatch(SHA1::equals))

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
@@ -19,6 +19,7 @@ import gov.loc.repository.bagit.hash.StandardSupportedAlgorithms;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.ingest.core.service.Deposit;
 import nl.knaw.dans.ingest.core.service.FileInfo;
+import nl.knaw.dans.ingest.core.service.ManifestHelper;
 import nl.knaw.dans.ingest.core.service.XPathEvaluator;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
 import org.apache.commons.lang3.StringUtils;
@@ -184,7 +185,7 @@ public class FileElement extends Base {
             .findFirst()
             .orElse(true);
 
-        var filePathToSha1 = getFilePathToSha1(deposit);
+        var filePathToSha1 = ManifestHelper.getFilePathToSha1(deposit);
         var result = new HashMap<Path, FileInfo>();
 
         XPathEvaluator.nodes(deposit.getFilesXml(), "//files:file").forEach(node -> {
@@ -198,21 +199,6 @@ public class FileElement extends Base {
 
             result.put(path, new FileInfo(absolutePath, sha1, toFileMeta(node, defaultRestrict)));
         });
-
-        return result;
-    }
-
-    static Map<Path, String> getFilePathToSha1(Deposit deposit) {
-        var result = new HashMap<Path, String>();
-        var bag = deposit.getBag();
-        var manifest = bag.getPayLoadManifests().stream()
-            .filter(item -> item.getAlgorithm().equals(StandardSupportedAlgorithms.SHA1))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Deposit bag does not have SHA-1 payload manifest"));
-
-        for (var entry : manifest.getFileToChecksumMap().entrySet()) {
-            result.put(deposit.getBagDir().relativize(entry.getKey()), entry.getValue());
-        }
 
         return result;
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
@@ -185,7 +185,7 @@ public class FileElement extends Base {
             .findFirst()
             .orElse(true);
 
-        var filePathToSha1 = ManifestHelper.getFilePathToSha1(deposit);
+        var filePathToSha1 = ManifestHelper.getFilePathToSha1(deposit.getBag());
         var result = new HashMap<Path, FileInfo>();
 
         XPathEvaluator.nodes(deposit.getFilesXml(), "//files:file").forEach(node -> {

--- a/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+import gov.loc.repository.bagit.reader.BagReader;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManifestHelperTest {
+    Path testDir = new File("target/test/" + getClass().getSimpleName()).toPath();
+
+    @BeforeEach
+    void clear() {
+        testDir.toFile().delete();
+    }
+
+    @Test
+    void getFilePathToSha1() throws Exception {
+        var bagDir = new File("src/test/resources/examples/valid-easy-submitted-no-doi/example-bag-medium").toPath();
+        var deposit = new Deposit();
+        deposit.setBagDir(bagDir);
+        deposit.setBag(new BagReader().read(bagDir));
+
+        var result = ManifestHelper.getFilePathToSha1(deposit);
+        assertThat(result).hasSize(5);
+    }
+
+    @Test
+    void addSha1ToBag() throws Exception {
+        var originalBag = "src/test/resources/examples/valid-easy-submitted-no-doi/example-bag-medium";
+        var bagDir = testDir.resolve("bag");
+        var sha1File = bagDir.resolve("manifest-sha1.txt").toFile();
+        FileUtils.copyDirectory(new File(originalBag), bagDir.toFile());
+        FileUtils.deleteQuietly(sha1File);
+
+        ManifestHelper.addSha1File(new BagReader().read(bagDir));
+        assertThat(sha1File).exists();
+    }
+}

--- a/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
@@ -40,7 +40,7 @@ public class ManifestHelperTest {
         deposit.setBagDir(bagDir);
         deposit.setBag(new BagReader().read(bagDir));
 
-        var result = ManifestHelper.getFilePathToSha1(deposit);
+        var result = ManifestHelper.getFilePathToSha1(deposit.getBag());
         assertThat(result).hasSize(5);
     }
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/ManifestHelperTest.java
@@ -52,7 +52,7 @@ public class ManifestHelperTest {
         FileUtils.copyDirectory(new File(originalBag), bagDir.toFile());
         FileUtils.deleteQuietly(sha1File);
 
-        ManifestHelper.addSha1File(new BagReader().read(bagDir));
+        ManifestHelper.ensureSha1ManifestPresent(new BagReader().read(bagDir));
         assertThat(sha1File).exists();
     }
 }


### PR DESCRIPTION
Fixes DD-1171: add SHA1 manifest if not present

# Description of changes
* add SHA1 manifest if not present
* update tagmanifest
* moved a static method from the `FileEment` class to the new `ManifestHelper` class

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
