### PR TITLE
DD-1255: upgrade dans-dataverse-client-lib: requires casts in test classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.12.0</version>
+            <version>0.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
@@ -21,7 +21,6 @@ import nl.knaw.dans.ingest.core.service.VaultMetadata;
 import nl.knaw.dans.ingest.core.service.XmlReaderImpl;
 import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
-import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveMultiValueField;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -33,13 +32,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.AUTHOR_NAME;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.CONTRIBUTOR_NAME;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DESCRIPTION;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DESCRIPTION_VALUE;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.NOTES_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MappingIntegrationTest {
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AuthorTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/AuthorTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.AUTHOR_NAME;
@@ -29,7 +30,7 @@ class AuthorTest extends BaseTest {
         var doc = readDocumentFromString("<dc:creator xmlns:dc=\"http://purl.org/dc/elements/1.1/\">Author Name</dc:creator>");
         var builder = new CompoundFieldBuilder("", true);
         Author.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        assertThat(builder.build().getValue())
+        assertThat(((CompoundField)builder.build()).getValue())
             .extracting(AUTHOR_NAME)
             .extracting("value")
             .containsOnly("Author Name");
@@ -54,7 +55,7 @@ class AuthorTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder("", true);
         Author.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        assertThat(builder.build().getValue())
+        assertThat(((CompoundField)builder.build()).getValue())
             .extracting(AUTHOR_NAME)
             .extracting("value")
             .containsOnly("I D Lastname");
@@ -74,7 +75,7 @@ class AuthorTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder("", true);
         Author.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        assertThat(builder.build().getValue())
+        assertThat(((CompoundField)builder.build()).getValue())
             .extracting(AUTHOR_NAME)
             .extracting("value")
             .containsOnly("Anti-Vampire League");

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/ContributorTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/ContributorTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.CONTRIBUTOR_NAME;
@@ -59,7 +60,7 @@ class ContributorTest extends BaseTest {
         Contributor.toContributorValueObject.build(builder, doc.getDocumentElement());
         var field = builder.build();
 
-        assertThat(field.getValue())
+        assertThat(((CompoundField)field).getValue())
             .extracting(CONTRIBUTOR_NAME)
             .extracting("value")
             .containsOnly("I de Lastname (Example Org)");

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DatesOfCollectionTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DatesOfCollectionTest.java
@@ -16,7 +16,12 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
+import nl.knaw.dans.lib.dataverse.model.dataset.SingleValueField;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DATE_OF_COLLECTION_END;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DATE_OF_COLLECTION_START;
@@ -32,7 +37,7 @@ class DatesOfCollectionTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder("", true);
         DatesOfCollection.toDistributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue())
             .extracting(DATE_OF_COLLECTION_START)
@@ -53,7 +58,7 @@ class DatesOfCollectionTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder("", true);
         DatesOfCollection.toDistributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField)builder.build();
 
         assertThat(field.getValue())
             .extracting(DATE_OF_COLLECTION_START)
@@ -74,7 +79,7 @@ class DatesOfCollectionTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder("", true);
         DatesOfCollection.toDistributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue())
             .extracting(DATE_OF_COLLECTION_START)

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiAuthorTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiAuthorTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.AUTHOR_AFFILIATION;
@@ -45,9 +46,9 @@ class DcxDaiAuthorTest extends BaseTest {
             + "                </dcx-dai:organization>\n"
             + "            </dcx-dai:author>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiAuthor.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(AUTHOR_NAME).extracting("value")
             .containsOnly("D.N. van den Aarden");
@@ -77,9 +78,9 @@ class DcxDaiAuthorTest extends BaseTest {
             + "                </dcx-dai:organization>\n"
             + "            </dcx-dai:author>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiAuthor.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(AUTHOR_NAME).extracting("value")
             .containsOnly("D.N. van den Aarden");
@@ -109,9 +110,9 @@ class DcxDaiAuthorTest extends BaseTest {
             + "                </dcx-dai:organization>\n"
             + "            </dcx-dai:author>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiAuthor.toContributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(CONTRIBUTOR_NAME).extracting("value")
             .containsOnly("D.N. van den Aarden (Utrecht University)");
@@ -129,9 +130,9 @@ class DcxDaiAuthorTest extends BaseTest {
             + "                </dcx-dai:organization>\n"
             + "            </dcx-dai:author>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiAuthor.toContributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(CONTRIBUTOR_NAME).extracting("value")
             .containsOnly("Utrecht University");

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiOrganizationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DcxDaiOrganizationTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.AUTHOR_IDENTIFIER;
@@ -37,9 +38,9 @@ class DcxDaiOrganizationTest extends BaseTest {
             + "    <dcx-dai:role xml:lang=\"en\">DataCurator</dcx-dai:role>\n"
             + "</dcx-dai:organization>\n");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toContributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(CONTRIBUTOR_NAME).extracting("value")
             .containsOnly("Anti-Vampire League");
@@ -54,9 +55,9 @@ class DcxDaiOrganizationTest extends BaseTest {
             + "    <dcx-dai:role xml:lang=\"en\">ContactPerson</dcx-dai:role>\n"
             + "</dcx-dai:organization>\n");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toContributorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(CONTRIBUTOR_TYPE).extracting("value")
             .containsOnly("Other");
@@ -68,9 +69,9 @@ class DcxDaiOrganizationTest extends BaseTest {
             + "    <dcx-dai:name xml:lang=\"en\">Anti-Vampire League</dcx-dai:name>\n"
             + "</dcx-dai:organization>\n");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(AUTHOR_NAME).extracting("value")
             .containsOnly("Anti-Vampire League");
@@ -83,9 +84,9 @@ class DcxDaiOrganizationTest extends BaseTest {
             + "    <dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>"
             + "</dcx-dai:organization>\n");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(AUTHOR_NAME).extracting("value")
             .containsOnly("Anti-Vampire League");
@@ -102,9 +103,9 @@ class DcxDaiOrganizationTest extends BaseTest {
             + "    <dcx-dai:VIAF>http://viaf.org/viaf/141399695</dcx-dai:VIAF>"
             + "</dcx-dai:organization>\n");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toAuthorValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(AUTHOR_NAME).extracting("value")
             .containsOnly("Anti-Vampire League");
@@ -124,9 +125,9 @@ class DcxDaiOrganizationTest extends BaseTest {
 
         assertTrue(DcxDaiOrganization.isFunder(doc.getDocumentElement()));
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DcxDaiOrganization.toGrantNumberValueObject.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(GRANT_NUMBER_VALUE).extracting("value")
             .containsOnly("");

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DepositPropertiesVaultMetadataTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DepositPropertiesVaultMetadataTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.OTHER_ID_AGENCY;
@@ -29,9 +30,9 @@ class DepositPropertiesVaultMetadataTest extends BaseTest {
 
     @Test
     void toOtherIdValue_should_create_OtherId_Json_object_for_other_ID_if_specified_in_correct_format() {
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         DepositPropertiesVaultMetadata.toOtherIdValue.build(builder, "PAN:123");
-        var field = builder.build();
+        var field = (CompoundField)builder.build();
 
         assertThat(field.getValue()).extracting(OTHER_ID_AGENCY).extracting("value")
             .containsOnly("PAN");
@@ -42,7 +43,7 @@ class DepositPropertiesVaultMetadataTest extends BaseTest {
 
     @Test
     void toOtherIdValue_should_throw_error_if_value_is_invalid() {
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
 
         assertThrows(IllegalArgumentException.class,
             () -> DepositPropertiesVaultMetadata.toOtherIdValue.build(builder, "in/valid"));
@@ -50,7 +51,7 @@ class DepositPropertiesVaultMetadataTest extends BaseTest {
 
     @Test
     void toOtherIdValue_should_throw_error_with_empty_values() {
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
 
         assertThrows(IllegalArgumentException.class,
             () -> DepositPropertiesVaultMetadata.toOtherIdValue.build(builder, ""));

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DescriptionTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/DescriptionTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DESCRIPTION_VALUE;
@@ -32,9 +33,9 @@ class DescriptionTest extends BaseTest {
             + "    Lorem ipsum.\n"
             + "</dc:description>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Description.toDescription.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue())
             .extracting(DESCRIPTION_VALUE)

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/IdentifierTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/IdentifierTest.java
@@ -16,6 +16,8 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
+import nl.knaw.dans.lib.dataverse.model.dataset.SingleCompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.ARCHIS_NUMBER_ID;
@@ -44,9 +46,9 @@ class IdentifierTest extends BaseTest {
                 + "    123\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Identifier.toOtherIdValue.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(OTHER_ID_AGENCY).extracting("value")
             .containsOnly("");
@@ -65,9 +67,9 @@ class IdentifierTest extends BaseTest {
                 + "    easy-dataset:18335\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Identifier.toOtherIdValue.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(OTHER_ID_AGENCY).extracting("value")
             .containsOnly("DANS-KNAW");
@@ -219,9 +221,9 @@ class IdentifierTest extends BaseTest {
                 + "    123\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Identifier.toNwoGrantNumber.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(GRANT_NUMBER_AGENCY).extracting("value")
             .containsOnly("NWO");
@@ -241,9 +243,9 @@ class IdentifierTest extends BaseTest {
                 + "    123\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Identifier.toRelatedPublicationValue.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue()).extracting(PUBLICATION_CITATION).extracting("value")
             .containsOnly("");
@@ -267,9 +269,9 @@ class IdentifierTest extends BaseTest {
                 + "    123\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         Identifier.toArchisNumberValue.build(builder, doc.getDocumentElement());
-        var field = builder.build();
+        var field = (CompoundField) builder.build();
 
         assertThat(field.getValue())
             .extracting(ARCHIS_NUMBER_TYPE)
@@ -293,7 +295,7 @@ class IdentifierTest extends BaseTest {
                 + "    123\n"
                 + "</dct:identifier>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         assertTrue(Identifier.isArchisNumber(doc.getDocumentElement()));
     }
 }

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.ingest.core.service.XPathEvaluator;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.Collectors;
@@ -51,7 +52,7 @@ class RelationTest extends BaseTest {
                 builder.nextValue();
             });
 
-        var result = builder.build();
+        var result = (CompoundField) builder.build();
         // the last call to nextValue creates an empty record, filter it out
         var list = result.getValue()
             .stream()

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialBoxTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialBoxTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.SPATIAL_BOX;
@@ -42,7 +43,7 @@ class SpatialBoxTest extends BaseTest {
 
         var builder = new CompoundFieldBuilder(SPATIAL_BOX, true);
         SpatialBox.toEasyTsmSpatialBoxValueObject.build(builder, doc.getDocumentElement());
-        var value = builder.build().getValue();
+        var value = ((CompoundField) builder.build()).getValue();
 
         assertThat(value)
             .extracting(x -> x.get(SPATIAL_BOX_SCHEME))
@@ -83,7 +84,7 @@ class SpatialBoxTest extends BaseTest {
         var builder = new CompoundFieldBuilder(SPATIAL_BOX, true);
         SpatialBox.toEasyTsmSpatialBoxValueObject.build(builder, doc.getDocumentElement());
 
-        assertThat(builder.build().getValue())
+        assertThat(((CompoundField)builder.build()).getValue())
             .extracting(x -> x.get(SPATIAL_BOX_SCHEME))
             .extracting("value")
             .containsOnly("RD (in m.)");

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialPointTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialPointTest.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
+import nl.knaw.dans.lib.dataverse.model.dataset.CompoundField;
 import org.junit.jupiter.api.Test;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.SPATIAL_POINT_SCHEME;
@@ -37,9 +38,9 @@ class SpatialPointTest extends BaseTest {
                 + "        <Point>52.08113 4.34510</Point>\n"
                 + "      </spatial>");
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         SpatialPoint.toEasyTsmSpatialPointValueObject.build(builder, doc.getDocumentElement());
-        var result = builder.build();
+        var result = (CompoundField) builder.build();
 
         assertThat(result.getValue())
             .extracting(SPATIAL_POINT_SCHEME)
@@ -64,9 +65,9 @@ class SpatialPointTest extends BaseTest {
                 + "        <Point>469470 209942</Point>\n"
                 + "      </spatial>", RD_SRS_NAME));
 
-        var builder = new CompoundFieldBuilder("", false);
+        var builder = new CompoundFieldBuilder("", true);
         SpatialPoint.toEasyTsmSpatialPointValueObject.build(builder, doc.getDocumentElement());
-        var result = builder.build();
+        var result = (CompoundField) builder.build();
 
         assertThat(result.getValue())
             .extracting(SPATIAL_POINT_SCHEME)


### PR DESCRIPTION
Fixes DD-1255: upgrade dans-dataverse-client-lib: requires casts in test classes

# Description of changes

# How to test

# Related PRs

* [ ] upgrade beyond snapshot of https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/37

# Notify

@DANS-KNAW/dataversedans
