### PR TITLE
DD-1245 dd-ingest-flow should call dd-validate-dans-bag WITH-DATASTATION-CONTEXT level

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidator.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.ingest.core.service;
 
+import nl.knaw.dans.validatedansbag.api.ValidateCommand;
 import nl.knaw.dans.validatedansbag.api.ValidateCommand.PackageTypeEnum;
 import nl.knaw.dans.validatedansbag.api.ValidateOk;
 
@@ -24,5 +25,5 @@ public interface DansBagValidator {
 
     void checkConnection();
 
-    ValidateOk validateBag(Path bagDir, PackageTypeEnum informationPackageType, int profileVersion);
+    ValidateOk validateBag(Path bagDir, PackageTypeEnum informationPackageType, int profileVersion, ValidateCommand.LevelEnum level);
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidatorImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DansBagValidatorImpl.java
@@ -65,8 +65,9 @@ public class DansBagValidatorImpl implements DansBagValidator {
     }
 
     @Override
-    public ValidateOk validateBag(Path bagDir, PackageTypeEnum informationPackageType, int profileVersion) {
+    public ValidateOk validateBag(Path bagDir, PackageTypeEnum informationPackageType, int profileVersion, ValidateCommand.LevelEnum level) {
         var command = new ValidateCommand()
+            .level(level)
             .bagLocation(bagDir.toString())
             .packageType(informationPackageType);
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -210,7 +210,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
 
         if (dansBagValidator != null) {
             var result = dansBagValidator.validateBag(
-                deposit.getBagDir(), ValidateCommand.PackageTypeEnum.DEPOSIT, 1);
+                deposit.getBagDir(), ValidateCommand.PackageTypeEnum.DEPOSIT, 1, ValidateCommand.LevelEnum.WITH_DATA_STATION_CONTEXT);
 
             if (!result.getIsCompliant()) {
                 var violations = result.getRuleViolations().stream()

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositMigrationTask.java
@@ -148,7 +148,7 @@ public class DepositMigrationTask extends DepositIngestTask {
 
         if (dansBagValidator != null) {
             var result = dansBagValidator.validateBag(
-                deposit.getBagDir(), ValidateCommand.PackageTypeEnum.MIGRATION, 1);
+                deposit.getBagDir(), ValidateCommand.PackageTypeEnum.MIGRATION, 1, ValidateCommand.LevelEnum.STAND_ALONE);
 
             if (!result.getIsCompliant()) {
                 var violations = result.getRuleViolations().stream()


### PR DESCRIPTION
Fixes DD-1245

# Description of changes
* `dd-validate-dans-bag` will now be called `WITH-DATA-STATION-CONTEXT` for SWORD2 and bulk-import deposits and still `STAND-ALONE` for migration deposits.

# How to test
1. Build and install the latest `dd-sword2` and `dd-ingest-flow` (this PR)
2. Assign the swordcreator role to a user
3. Do a SWORD deposit for that user with `dd-dans-sword2-examples`.


# Notify

@DANS-KNAW/dataversedans
