### PR TITLE
DD-1282: configurable languages for SpatialCoverage

### DIFF
--- a/src/main/assembly/dist/cfg/spatial-coverage-country-terms.txt
+++ b/src/main/assembly/dist/cfg/spatial-coverage-country-terms.txt
@@ -1,0 +1,249 @@
+Afghanistan
+Åland Islands
+Albania
+Algeria
+American Samoa
+Andorra
+Angola
+Anguilla
+Antarctica
+Antigua and Barbuda
+Argentina
+Armenia
+Aruba
+Australia
+Austria
+Azerbaijan
+Bahamas
+Bahrain
+Bangladesh
+Barbados
+Belarus
+Belgium
+Belize
+Benin
+Bermuda
+Bhutan
+Bolivia, Plurinational State of
+Bonaire, Sint Eustatius and Saba
+Bosnia and Herzegovina
+Botswana
+Bouvet Island
+Brazil
+British Indian Ocean Territory
+Brunei Darussalam
+Bulgaria
+Burkina Faso
+Burundi
+Cambodia
+Cameroon
+Canada
+Cape Verde
+Cayman Islands
+Central African Republic
+Chad
+Chile
+China
+Christmas Island
+Cocos (Keeling) Islands
+Colombia
+Comoros
+Congo
+Congo, the Democratic Republic of the
+Cook Islands
+Costa Rica
+Côte d'Ivoire
+Croatia
+Cuba
+Curaçao
+Cyprus
+Czech Republic
+Denmark
+Djibouti
+Dominica
+Dominican Republic
+Ecuador
+Egypt
+El Salvador
+Equatorial Guinea
+Eritrea
+Estonia
+Ethiopia
+Falkland Islands (Malvinas)
+Faroe Islands
+Fiji
+Finland
+France
+French Guiana
+French Polynesia
+French Southern Territories
+Gabon
+Gambia
+Georgia
+Germany
+Ghana
+Gibraltar
+Greece
+Greenland
+Grenada
+Guadeloupe
+Guam
+Guatemala
+Guernsey
+Guinea
+Guinea-Bissau
+Guyana
+Haiti
+Heard Island and Mcdonald Islands
+Holy See (Vatican City State)
+Honduras
+Hong Kong
+Hungary
+Iceland
+India
+Indonesia
+Iran, Islamic Republic of
+Iraq
+Ireland
+Isle of Man
+Israel
+Italy
+Jamaica
+Japan
+Jersey
+Jordan
+Kazakhstan
+Kenya
+Kiribati
+Korea, Democratic People's Republic of
+Korea, Republic of
+Kuwait
+Kyrgyzstan
+Lao People's Democratic Republic
+Latvia
+Lebanon
+Lesotho
+Liberia
+Libya
+Liechtenstein
+Lithuania
+Luxembourg
+Macao
+Macedonia, the Former Yugoslav Republic of
+Madagascar
+Malawi
+Malaysia
+Maldives
+Mali
+Malta
+Marshall Islands
+Martinique
+Mauritania
+Mauritius
+Mayotte
+Mexico
+Micronesia, Federated States of
+Moldova, Republic of
+Monaco
+Mongolia
+Montenegro
+Montserrat
+Morocco
+Mozambique
+Myanmar
+Namibia
+Nauru
+Nepal
+Netherlands
+New Caledonia
+New Zealand
+Nicaragua
+Niger
+Nigeria
+Niue
+Norfolk Island
+Northern Mariana Islands
+Norway
+Oman
+Pakistan
+Palau
+Palestine, State of
+Panama
+Papua New Guinea
+Paraguay
+Peru
+Philippines
+Pitcairn
+Poland
+Portugal
+Puerto Rico
+Qatar
+Réunion
+Romania
+Russian Federation
+Rwanda
+Saint Barthélemy
+Saint Helena, Ascension and Tristan da Cunha
+Saint Kitts and Nevis
+Saint Lucia
+Saint Martin (French part)
+Saint Pierre and Miquelon
+Saint Vincent and the Grenadines
+Samoa
+San Marino
+Sao Tome and Principe
+Saudi Arabia
+Senegal
+Serbia
+Seychelles
+Sierra Leone
+Singapore
+Sint Maarten (Dutch part)
+Slovakia
+Slovenia
+Solomon Islands
+Somalia
+South Africa
+South Georgia and the South Sandwich Islands
+South Sudan
+Spain
+Sri Lanka
+Sudan
+Suriname
+Svalbard and Jan Mayen
+Swaziland
+Sweden
+Switzerland
+Syrian Arab Republic
+Taiwan, Province of China
+Tajikistan
+Tanzania, United Republic of
+Thailand
+Timor-Leste
+Togo
+Tokelau
+Tonga
+Trinidad and Tobago
+Tunisia
+Turkey
+Turkmenistan
+Turks and Caicos Islands
+Tuvalu
+Uganda
+Ukraine
+United Arab Emirates
+United Kingdom
+United States
+United States Minor Outlying Islands
+Uruguay
+Uzbekistan
+Vanuatu
+Venezuela, Bolivarian Republic of
+Viet Nam
+Virgin Islands, British
+Virgin Islands, U.S.
+Wallis and Futuna
+Western Sahara
+Yemen
+Zambia
+Zimbabwe

--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
@@ -108,6 +108,7 @@ public class DdIngestFlowApplication extends Application<DdIngestFlowConfigurati
         final var depositToDvDatasetMetadataMapperFactory = new DepositToDvDatasetMetadataMapperFactory(
             configuration.getIngestFlow().getIso1ToDataverseLanguage(),
             configuration.getIngestFlow().getIso2ToDataverseLanguage(),
+            configuration.getIngestFlow().getSpatialCoverageCountryTerms(),
             dataverseClient
         );
 

--- a/src/main/java/nl/knaw/dans/ingest/IngestFlowConfigReader.java
+++ b/src/main/java/nl/knaw/dans/ingest/IngestFlowConfigReader.java
@@ -37,6 +37,7 @@ public class IngestFlowConfigReader {
         config.setReportIdToTerm(getMap(config, "ABR-reports.csv", "URI-suffix", "Term"));
         config.setVariantToLicense(getMap(config, "license-uri-variants.csv", "Variant", "Normalized"));
         config.setSupportedLicenses(getUriList(config, "supported-licenses.txt"));
+        config.setSpatialCoverageCountryTerms(FileUtils.readLines(config.getMappingDefsDir().resolve("spatial-coverage-country-terms.txt").toFile(), StandardCharsets.UTF_8));
     }
 
     private static Map<String, String> loadCsvToMap(Path path, String keyColumn, String valueColumn) throws IOException {

--- a/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
@@ -67,6 +67,7 @@ public class IngestFlowConfig {
     private Map<String, String> reportIdToTerm;
     private Map<String, String> variantToLicense;
     private List<URI> supportedLicenses;
+    private List<String> spatialCoverageCountryTerms;
 
     public IngestAreaConfig getImportConfig() {
         return importConfig;
@@ -178,5 +179,13 @@ public class IngestFlowConfig {
 
     public void setSupportedLicenses(List<URI> supportedLicenses) {
         this.supportedLicenses = supportedLicenses;
+    }
+
+    public List<String> getSpatialCoverageCountryTerms() {
+        return spatialCoverageCountryTerms;
+    }
+
+    public void setSpatialCoverageCountryTerms(List<String> spatialCoverageCountryTerms) {
+        this.spatialCoverageCountryTerms = spatialCoverageCountryTerms;
     }
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -94,14 +94,16 @@ public class DepositToDvDatasetMetadataMapper {
 
     private final Map<String, String> iso1ToDataverseLanguage;
     private final Map<String, String> iso2ToDataverseLanguage;
+    private List<String> spatialCoverageCountryTerms;
     private final boolean deduplicate;
 
     DepositToDvDatasetMetadataMapper(boolean deduplicate, Set<String> activeMetadataBlocks, Map<String, String> iso1ToDataverseLanguage,
-        Map<String, String> iso2ToDataverseLanguage) {
+        Map<String, String> iso2ToDataverseLanguage, List<String> spatialCoverageCountryTerms) {
         this.deduplicate = deduplicate;
         this.activeMetadataBlocks = activeMetadataBlocks;
         this.iso1ToDataverseLanguage = iso1ToDataverseLanguage;
         this.iso2ToDataverseLanguage = iso2ToDataverseLanguage;
+        this.spatialCoverageCountryTerms = spatialCoverageCountryTerms;
     }
 
     public Dataset toDataverseDataset(
@@ -211,8 +213,10 @@ public class DepositToDvDatasetMetadataMapper {
             temporalSpatialFields.addSpatialPoint(getDcxGmlSpatial(ddm)
                 .filter(node -> SpatialPoint.hasChildNode(node, "/Point")), SpatialPoint.toEasyTsmSpatialPointValueObject); // TS002, TS003
             temporalSpatialFields.addSpatialBox(getBoundedBy(ddm), SpatialBox.toEasyTsmSpatialBoxValueObject); // TS004, TS005
-            temporalSpatialFields.addSpatialCoverageControlled(getSpatial(ddm).map(SpatialCoverage::toControlledSpatialValue)); // TS006
-            temporalSpatialFields.addSpatialCoverageUncontrolled(getSpatial(ddm).map(SpatialCoverage::toUncontrolledSpatialValue)); // TS007
+            temporalSpatialFields.addSpatialCoverageControlled(getSpatial(ddm)
+                .map(node -> SpatialCoverage.toControlledSpatialValue(node, spatialCoverageCountryTerms))); // TS006
+            temporalSpatialFields.addSpatialCoverageUncontrolled(getSpatial(ddm)
+                .map((Node node) -> SpatialCoverage.toUncontrolledSpatialValue(node, spatialCoverageCountryTerms))); // TS007
         }
 
         if (activeMetadataBlocks.contains("dansDataVaultMetadata") && vaultMetadata != null) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperFactory.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperFactory.java
@@ -21,6 +21,7 @@ import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlockSummary;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,11 +31,14 @@ public class DepositToDvDatasetMetadataMapperFactory {
 
     private final Map<String, String> iso1ToDataverseLanguage;
     private final Map<String, String> iso2ToDataverseLanguage;
+    private final List<String> spatialCoverageCountryTerms;
     private final DataverseClient dataverseClient;
 
-    public DepositToDvDatasetMetadataMapperFactory(Map<String, String> iso1ToDataverseLanguage, Map<String, String> iso2ToDataverseLanguage, DataverseClient dataverseClient) {
+    public DepositToDvDatasetMetadataMapperFactory(Map<String, String> iso1ToDataverseLanguage, Map<String, String> iso2ToDataverseLanguage,
+        List<String> spatialCoverageCountryTerms, DataverseClient dataverseClient) {
         this.iso1ToDataverseLanguage = iso1ToDataverseLanguage;
         this.iso2ToDataverseLanguage = iso2ToDataverseLanguage;
+        this.spatialCoverageCountryTerms = spatialCoverageCountryTerms;
         this.dataverseClient = dataverseClient;
     }
 
@@ -43,7 +47,8 @@ public class DepositToDvDatasetMetadataMapperFactory {
             deduplicate,
             getActiveMetadataBlocks(),
             iso1ToDataverseLanguage,
-            iso2ToDataverseLanguage
+            iso2ToDataverseLanguage,
+            spatialCoverageCountryTerms
         );
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialCoverage.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/SpatialCoverage.java
@@ -17,16 +17,10 @@ package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import org.w3c.dom.Node;
 
+import java.util.List;
 import java.util.Set;
 
 public class SpatialCoverage extends Base {
-
-    private static final Set<String> controlledValues = Set.of(
-        "Netherlands",
-        "United Kingdom",
-        "Belgium",
-        "Germany"
-    );
 
     public static boolean hasNoChildElement(Node node) {
         return !hasChildElement(node);
@@ -47,13 +41,13 @@ public class SpatialCoverage extends Base {
         return false;
     }
 
-    public static String toControlledSpatialValue(Node node) {
+    public static String toControlledSpatialValue(Node node, List<String> spatialCoverageCountryTerms) {
         var text = node.getTextContent().trim();
-        return controlledValues.contains(text) ? text : null;
+        return spatialCoverageCountryTerms.contains(text) ? text : null;
     }
 
-    public static String toUncontrolledSpatialValue(Node node) {
+    public static String toUncontrolledSpatialValue(Node node, List<String> spatialCoverageCountryTerms) {
         var text = node.getTextContent().trim();
-        return controlledValues.contains(text) ? null : text;
+        return spatialCoverageCountryTerms.contains(text) ? null : text;
     }
 }

--- a/src/test/java/nl/knaw/dans/ingest/DdIngestFlowConfigurationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/DdIngestFlowConfigurationTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -44,6 +44,7 @@ public class DdIngestFlowConfigurationTest {
 
     @Test
     public void canReadAssembly() throws IOException, ConfigurationException {
+        System.out.println(new ObjectMapper().writeValueAsString(Map.of("http://schema.org/license", "")));
         factory.build(FileInputStream::new, "src/main/assembly/dist/cfg/config.yml");
     }
 

--- a/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
@@ -121,6 +121,7 @@ public class DepositStartImportTaskWrapperTest {
     DepositToDvDatasetMetadataMapperFactory getMapperFactory() {
         return new DepositToDvDatasetMetadataMapperFactory(
             iso1ToDataverseLanguage, iso2ToDataverseLanguage,
+            List.of("Netherlands", "United Kingdom", "Belgium", "Germany"),
             Mockito.mock(DataverseClient.class)
         );
     }

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
@@ -48,6 +48,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
     private final Map<String, String> iso1ToDataverseLanguage = new HashMap<>();
     private final Map<String, String> iso2ToDataverseLanguage = new HashMap<>();
+    private final List<String> spatialCoverageCountryTerms = List.of("Netherlands", "United Kingdom", "Belgium", "Germany");
 
     Document readDocument(String name) throws ParserConfigurationException, IOException, SAXException {
         return xmlReader.readXmlFile(Path.of(
@@ -61,8 +62,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
     DepositToDvDatasetMetadataMapper getMapper() {
         return new DepositToDvDatasetMetadataMapper(
-            true, activeMetadataBlocks, iso1ToDataverseLanguage, iso2ToDataverseLanguage
-        );
+            true, activeMetadataBlocks, iso1ToDataverseLanguage, iso2ToDataverseLanguage, spatialCoverageCountryTerms);
     }
 
     @BeforeEach
@@ -136,7 +136,7 @@ class DepositToDvDatasetMetadataMapperTest {
     @Test
     void processMetadataBlock_should_deduplicate_items_for_PrimitiveFieldBuilder() throws Exception {
         var fields = new HashMap<String, MetadataBlock>();
-        var mapper = new DepositToDvDatasetMetadataMapper(true, Set.of("citation"), Map.of(), Map.of());
+        var mapper = new DepositToDvDatasetMetadataMapper(true, Set.of("citation"), Map.of(), Map.of(), spatialCoverageCountryTerms);
         var builder = new ArchaeologyFieldBuilder();
         builder.addArchisZaakId(Stream.of(
             "TEST",
@@ -156,7 +156,7 @@ class DepositToDvDatasetMetadataMapperTest {
     @Test
     void processMetadataBlock_should_deduplicate_items_for_CompoundFieldBuilder() throws Exception {
         var fields = new HashMap<String, MetadataBlock>();
-        var mapper = new DepositToDvDatasetMetadataMapper(true, Set.of("citation"), Map.of(), Map.of());
+        var mapper = new DepositToDvDatasetMetadataMapper(true, Set.of("citation"), Map.of(), Map.of(), spatialCoverageCountryTerms);
         var builder = new ArchaeologyFieldBuilder();
         builder.addArchisZaakId(Stream.of(
             "TEST",

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
@@ -60,7 +60,7 @@ class MappingIntegrationTest {
         iso2ToDataverseLanguage.put("dut", "Dutch");
         iso2ToDataverseLanguage.put("ger", "German");
         return new DepositToDvDatasetMetadataMapper(
-            true, activeMetadataBlocks, iso1ToDataverseLanguage, iso2ToDataverseLanguage
+            true, activeMetadataBlocks, iso1ToDataverseLanguage, iso2ToDataverseLanguage, List.of("Netherlands", "United Kingdom", "Belgium", "Germany")
         ).toDataverseDataset(ddm, null, null, null, vaultMetadata, hasRestrictedOrNoneFiles);
     }
 

--- a/src/test/resources/debug-etc/spatial-coverage-country-terms.txt
+++ b/src/test/resources/debug-etc/spatial-coverage-country-terms.txt
@@ -1,0 +1,249 @@
+Afghanistan
+Åland Islands
+Albania
+Algeria
+American Samoa
+Andorra
+Angola
+Anguilla
+Antarctica
+Antigua and Barbuda
+Argentina
+Armenia
+Aruba
+Australia
+Austria
+Azerbaijan
+Bahamas
+Bahrain
+Bangladesh
+Barbados
+Belarus
+Belgium
+Belize
+Benin
+Bermuda
+Bhutan
+Bolivia, Plurinational State of
+Bonaire, Sint Eustatius and Saba
+Bosnia and Herzegovina
+Botswana
+Bouvet Island
+Brazil
+British Indian Ocean Territory
+Brunei Darussalam
+Bulgaria
+Burkina Faso
+Burundi
+Cambodia
+Cameroon
+Canada
+Cape Verde
+Cayman Islands
+Central African Republic
+Chad
+Chile
+China
+Christmas Island
+Cocos (Keeling) Islands
+Colombia
+Comoros
+Congo
+Congo, the Democratic Republic of the
+Cook Islands
+Costa Rica
+Côte d'Ivoire
+Croatia
+Cuba
+Curaçao
+Cyprus
+Czech Republic
+Denmark
+Djibouti
+Dominica
+Dominican Republic
+Ecuador
+Egypt
+El Salvador
+Equatorial Guinea
+Eritrea
+Estonia
+Ethiopia
+Falkland Islands (Malvinas)
+Faroe Islands
+Fiji
+Finland
+France
+French Guiana
+French Polynesia
+French Southern Territories
+Gabon
+Gambia
+Georgia
+Germany
+Ghana
+Gibraltar
+Greece
+Greenland
+Grenada
+Guadeloupe
+Guam
+Guatemala
+Guernsey
+Guinea
+Guinea-Bissau
+Guyana
+Haiti
+Heard Island and Mcdonald Islands
+Holy See (Vatican City State)
+Honduras
+Hong Kong
+Hungary
+Iceland
+India
+Indonesia
+Iran, Islamic Republic of
+Iraq
+Ireland
+Isle of Man
+Israel
+Italy
+Jamaica
+Japan
+Jersey
+Jordan
+Kazakhstan
+Kenya
+Kiribati
+Korea, Democratic People's Republic of
+Korea, Republic of
+Kuwait
+Kyrgyzstan
+Lao People's Democratic Republic
+Latvia
+Lebanon
+Lesotho
+Liberia
+Libya
+Liechtenstein
+Lithuania
+Luxembourg
+Macao
+Macedonia, the Former Yugoslav Republic of
+Madagascar
+Malawi
+Malaysia
+Maldives
+Mali
+Malta
+Marshall Islands
+Martinique
+Mauritania
+Mauritius
+Mayotte
+Mexico
+Micronesia, Federated States of
+Moldova, Republic of
+Monaco
+Mongolia
+Montenegro
+Montserrat
+Morocco
+Mozambique
+Myanmar
+Namibia
+Nauru
+Nepal
+Netherlands
+New Caledonia
+New Zealand
+Nicaragua
+Niger
+Nigeria
+Niue
+Norfolk Island
+Northern Mariana Islands
+Norway
+Oman
+Pakistan
+Palau
+Palestine, State of
+Panama
+Papua New Guinea
+Paraguay
+Peru
+Philippines
+Pitcairn
+Poland
+Portugal
+Puerto Rico
+Qatar
+Réunion
+Romania
+Russian Federation
+Rwanda
+Saint Barthélemy
+Saint Helena, Ascension and Tristan da Cunha
+Saint Kitts and Nevis
+Saint Lucia
+Saint Martin (French part)
+Saint Pierre and Miquelon
+Saint Vincent and the Grenadines
+Samoa
+San Marino
+Sao Tome and Principe
+Saudi Arabia
+Senegal
+Serbia
+Seychelles
+Sierra Leone
+Singapore
+Sint Maarten (Dutch part)
+Slovakia
+Slovenia
+Solomon Islands
+Somalia
+South Africa
+South Georgia and the South Sandwich Islands
+South Sudan
+Spain
+Sri Lanka
+Sudan
+Suriname
+Svalbard and Jan Mayen
+Swaziland
+Sweden
+Switzerland
+Syrian Arab Republic
+Taiwan, Province of China
+Tajikistan
+Tanzania, United Republic of
+Thailand
+Timor-Leste
+Togo
+Tokelau
+Tonga
+Trinidad and Tobago
+Tunisia
+Turkey
+Turkmenistan
+Turks and Caicos Islands
+Tuvalu
+Uganda
+Ukraine
+United Arab Emirates
+United Kingdom
+United States
+United States Minor Outlying Islands
+Uruguay
+Uzbekistan
+Vanuatu
+Venezuela, Bolivarian Republic of
+Viet Nam
+Virgin Islands, British
+Virgin Islands, U.S.
+Wallis and Futuna
+Western Sahara
+Yemen
+Zambia
+Zimbabwe


### PR DESCRIPTION
Fixes DD-1282: configurable languages for SpatialCoverage

# Description of changes

# How to test

as documented with 

     <ddm:dcmiMetadata>
         <dct:spatial>Tunisia</dct:spatial>
         <dct:spatial>Nederland</dct:spatial>
    ...

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
