### PR TITLE
DD-1292: map multiple Series-information to single compound field

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -174,7 +174,7 @@ public class DepositToDvDatasetMetadataMapper {
             citationFields.addDateOfDeposit(dateOfDeposit); // CIT025A
             citationFields.addDatesOfCollection(getDatesOfCollection(ddm)
                 .filter(DatesOfCollection::isValidDatesOfCollectionPattern), DatesOfCollection.toDateOfCollectionValue); // CIT026
-            citationFields.addSeries(getDcmiDdmDescriptions(ddm).filter(Description::isSeriesInformation), Description.toSeries); // CIT027
+            citationFields.addSeries(getDcmiDdmDescriptions(ddm).filter(Description::isSeriesInformation)); // CIT027
             citationFields.addDataSources(getDataSources(ddm)); // CIT028
         }
         else {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.ingest.core.service.mapper.builder;
 
+import nl.knaw.dans.ingest.core.service.mapper.mapping.Description;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 import org.w3c.dom.Node;
 
@@ -49,8 +50,10 @@ public class CitationFieldBuilder extends FieldBuilder {
         addSingleString(TITLE, nodes);
     }
 
-    public void addSeries(Stream<Node> stream, CompoundFieldGenerator<Node> generator) {
-        addSingleCompound(SERIES, stream, generator);
+    public void addSeries(Stream<Node> stream) {
+        var builder = getCompoundBuilder(SERIES, false);
+        Description.toSeries(builder, stream);
+        builder.build();
     }
 
     public void addOtherIds(Stream<Node> stream, CompoundFieldGenerator<Node> generator) {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/FieldBuilder.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/FieldBuilder.java
@@ -114,13 +114,6 @@ public abstract class FieldBuilder {
         });
     }
 
-    public void addSingleCompound(String name, Stream<Node> data, CompoundFieldGenerator<Node> generator) {
-        data.forEach(value -> {
-            var builder = getCompoundBuilder(name, false);
-            generator.build(builder, value);
-        });
-    }
-
     public void addMultipleString(String name, Stream<String> data, CompoundFieldGenerator<String> generator) {
         data.forEach(value -> {
             var builder = getCompoundBuilder(name, true);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/Description.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/Description.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ingest.core.service.mapper.mapping;
 
 import nl.knaw.dans.ingest.core.service.mapper.builder.CompoundFieldGenerator;
+import nl.knaw.dans.lib.dataverse.CompoundFieldBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Node;
 
@@ -23,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.DESCRIPTION_VALUE;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.SERIES_INFORMATION;
@@ -49,8 +51,9 @@ public class Description extends Base {
 
         builder.addSubfield(DESCRIPTION_VALUE, String.format("%s: %s", prefix, value.getTextContent()));
     };
-    public static CompoundFieldGenerator<Node> toSeries = (builder, value) -> {
-        var text = newlineToHtml(value.getTextContent());
+    static public void toSeries (CompoundFieldBuilder builder, Stream<Node> stream) {
+        var collected = stream.map(Node::getTextContent).collect(Collectors.joining("\n\n"));
+        var text = newlineToHtml(collected);
         builder.addSubfield(SERIES_INFORMATION, text);
     };
 


### PR DESCRIPTION
Fixes DD-1292: map multiple Series-information to single compound field

# Description of changes

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
