### PR TITLE
Solve TermsOfAccess validation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
+            <version>0.17.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.17.1-SNAPSHOT</version>
+            <version>0.18.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
@@ -27,6 +27,7 @@ import nl.knaw.dans.ingest.core.service.mapper.mapping.FileElement;
 import nl.knaw.dans.ingest.core.service.mapper.mapping.License;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.DataverseResponse;
 import nl.knaw.dans.lib.dataverse.Version;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
 import nl.knaw.dans.lib.dataverse.model.file.DataFile;
@@ -47,6 +48,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -245,27 +247,5 @@ public abstract class DatasetEditor {
             .map(DatasetEditor::parseDate)
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Deposit without a ddm:available element"));
-    }
-
-    void configureEnableAccessRequests(String persistentId, boolean canEnable) throws IOException, DataverseException {
-        var api = dataverseClient.accessRequests(persistentId);
-
-        var ddm = deposit.getDdm();
-        var files = deposit.getFilesXml();
-
-        var accessRights = XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/ddm:accessRights")
-            .findFirst()
-            .orElseThrow();
-
-        var enable = AccessRights.isEnableRequests(accessRights, files);
-
-        log.trace("AccessRequests enable {} can {}", enable, canEnable);
-
-        if (!enable) {
-            api.disable();
-        }
-        else if (canEnable) {
-            api.enable();
-        }
     }
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -25,8 +25,9 @@ import nl.knaw.dans.lib.dataverse.DatasetApi;
 import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.lib.dataverse.Version;
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
-import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -46,16 +47,13 @@ import java.util.stream.Stream;
 
 @Slf4j
 public class DatasetUpdater extends DatasetEditor {
-    private final Map<String, MetadataBlock> metadataBlocks;
-
     protected DatasetUpdater(boolean isMigration, Dataset dataset,
         Deposit deposit, Map<String, String> variantToLicense, List<URI> supportedLicenses,
         Pattern fileExclusionPattern, ZipFileHandler zipFileHandler,
-        ObjectMapper objectMapper, Map<String, MetadataBlock> metadataBlocks, DatasetService datasetService) {
+        ObjectMapper objectMapper, DatasetService datasetService) {
         super(isMigration, dataset, deposit, variantToLicense, supportedLicenses,
             fileExclusionPattern,
             zipFileHandler, objectMapper, datasetService);
-        this.metadataBlocks = metadataBlocks;
     }
 
     @Override
@@ -80,7 +78,16 @@ public class DatasetUpdater extends DatasetEditor {
                     throw new CannotUpdateDraftDatasetException(deposit);
                 }
 
-                api.updateMetadata(metadataBlocks);
+                var latestVersion = api.getLatestVersion().getData().getLatestVersion();
+                var datasetVersion = dataset.getDatasetVersion();
+
+                // Copy the terms of access from the latest version (not automatically inherited, alas!) if no new terms were provided.
+                if (StringUtils.isBlank(datasetVersion.getTermsOfAccess())) {
+                    datasetVersion.setTermsOfAccess(latestVersion.getTermsOfAccess());
+                }
+                // Possibly disable file access request (never enable if it was not already).
+                datasetVersion.setFileAccessRequest(deposit.allowAccessRequests() && api.getLatestVersion().getData().getLatestVersion().getFileAccessRequest());
+                api.updateMetadata(datasetVersion);
                 api.awaitUnlock();
 
                 var license = toJson(Map.of("http://schema.org/license", getLicense(deposit.getDdm())));
@@ -185,16 +192,11 @@ public class DatasetUpdater extends DatasetEditor {
 
                 embargoFiles(doi, dateAvailable, fileIdsToEmbargo);
 
-                /*
-                 * Cannot enable requests if they were disallowed because of closed files in a previous version. However, disabling is possible because the update may add a closed file.
-                 */
-                configureEnableAccessRequests(doi, false);
-
                 return doi;
             }
             catch (Exception e) {
                 log.error("Error updating dataset, deleting draft", e);
-                deleteDraftIfExists(doi);
+                //                deleteDraftIfExists(doi);
                 throw e;
             }
         }
@@ -378,7 +380,7 @@ public class DatasetUpdater extends DatasetEditor {
             }
         }
 
-        // check if any of them have a checksum that is not SHA-1
+        // check if any of them have a checksum that is not SHA-1restrictedFilesPresent
         for (var fileMeta : pathToFileInfoInLatestVersion.values()) {
             var checksumType = fileMeta.getDataFile().getChecksum().getType();
             log.trace("Filemeta checksum type for file {}: {}", fileMeta.getLabel(), checksumType);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -80,13 +80,17 @@ public class DatasetUpdater extends DatasetEditor {
 
                 var latestVersion = api.getLatestVersion().getData().getLatestVersion();
                 var datasetVersion = dataset.getDatasetVersion();
+                var fileAccessRequest = deposit.allowAccessRequests() && api.getLatestVersion().getData().getLatestVersion().getFileAccessRequest();
+                // Possibly disable file access request (never enable if it was not already).
+                datasetVersion.setFileAccessRequest(fileAccessRequest);
 
                 // Copy the terms of access from the latest version (not automatically inherited, alas!) if no new terms were provided.
                 if (StringUtils.isBlank(datasetVersion.getTermsOfAccess())) {
-                    datasetVersion.setTermsOfAccess(latestVersion.getTermsOfAccess());
+                    datasetVersion.setTermsOfAccess(StringUtils.isNotBlank(latestVersion.getTermsOfAccess()) ?
+                        latestVersion.getTermsOfAccess() :
+                        // if fileAccessRequest ends up false, Dataverse requires termsOfAccess to be filled in.
+                        (fileAccessRequest ? "" : "N/a"));
                 }
-                // Possibly disable file access request (never enable if it was not already).
-                datasetVersion.setFileAccessRequest(deposit.allowAccessRequests() && api.getLatestVersion().getData().getLatestVersion().getFileAccessRequest());
                 api.updateMetadata(datasetVersion);
                 api.awaitUnlock();
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -215,7 +215,7 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     void doRun() throws Exception {
         var deposit = getDeposit();
         var isUpdate = deposit.isUpdate();
-
+        log.debug("Is update: {}", isUpdate);
         if (isUpdate) {
             log.debug("Figuring out the doi for deposit {}", deposit.getDepositId());
             var dataverseDoi = resolveDoi(deposit);
@@ -237,9 +237,6 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     void createOrUpdateDataset(boolean isUpdate) throws Exception {
         // get metadata
         var dataverseDataset = getMetadata();
-
-        log.debug("Is update: {}", isUpdate);
-
         var persistentId = isUpdate
             ? newDatasetUpdater(dataverseDataset).performEdit()
             : newDatasetCreator(dataverseDataset, depositorRole).performEdit();
@@ -362,8 +359,6 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     }
 
     DatasetEditor newDatasetUpdater(Dataset dataset, boolean isMigration) {
-        var blocks = dataset.getDatasetVersion().getMetadataBlocks();
-
         return new DatasetUpdater(
             isMigration,
             dataset,
@@ -373,7 +368,6 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
             fileExclusionPattern,
             zipFileHandler,
             new ObjectMapper(),
-            blocks,
             datasetService
         );
     }
@@ -404,10 +398,6 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     Dataset getMetadata() {
         var date = getDateOfDeposit();
         var contact = getDatasetContact();
-        var accessibleToValues = XPathEvaluator
-            .strings(deposit.getFilesXml(), "/files:files/files:file/files:accessibleToRights")
-            .collect(Collectors.toList());
-
         var mapper = datasetMetadataMapperFactory.createMapper(false); // TODO: WHY IS THIS ALWAYS FALSE?
         return mapper.toDataverseDataset(
             deposit.getDdm(),
@@ -415,9 +405,8 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
             date.orElse(null),
             contact.orElse(null),
             deposit.getVaultMetadata(),
-            // TRM002
-            accessibleToValues.contains("NONE"),
-            accessibleToValues.contains("RESTRICTED_REQUEST") || accessibleToValues.contains("KNOWN"));
+            deposit.restrictedFilesPresent()
+      );
     }
 
     Optional<String> getDateOfDeposit() {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -94,7 +94,7 @@ public class DepositToDvDatasetMetadataMapper {
 
     private final Map<String, String> iso1ToDataverseLanguage;
     private final Map<String, String> iso2ToDataverseLanguage;
-    private List<String> spatialCoverageCountryTerms;
+    private final List<String> spatialCoverageCountryTerms;
     private final boolean deduplicate;
 
     DepositToDvDatasetMetadataMapper(boolean deduplicate, Set<String> activeMetadataBlocks, Map<String, String> iso1ToDataverseLanguage,
@@ -112,9 +112,8 @@ public class DepositToDvDatasetMetadataMapper {
         @Nullable String dateOfDeposit,
         @Nullable AuthenticatedUser contactData,
         @NonNull VaultMetadata vaultMetadata,
-        boolean filesThatAreAccessibleToNonePresentInDeposit,
-        boolean filesThatAreRestrictedRequestPresentInDeposit) throws MissingRequiredFieldException {
-        var termsOfAccess = "N/a";
+        boolean restrictedFilesPresent) throws MissingRequiredFieldException {
+        var termsOfAccess = "";
 
         if (activeMetadataBlocks.contains("citation")) {
             checkRequiredField(TITLE, getTitles(ddm));
@@ -145,12 +144,8 @@ public class DepositToDvDatasetMetadataMapper {
             citationFields.addDescription(getDcmiDctermsDescriptions(ddm), Description.toDescription); // CIT012
             citationFields.addDescription(getDcmiDdmDescriptions(ddm).filter(Description::isNotMapped), Description.toDescription); // CIT012
 
-            if (filesThatAreAccessibleToNonePresentInDeposit) {
+            if (restrictedFilesPresent) {
                 // TRM005
-                termsOfAccess = getDctAccessRights(ddm).map(Node::getTextContent).findFirst().orElse(termsOfAccess);
-            }
-            else if (filesThatAreRestrictedRequestPresentInDeposit) {
-                // TRM006
                 termsOfAccess = getDctAccessRights(ddm).map(Node::getTextContent).findFirst().orElse("");
             }
             else {
@@ -279,6 +274,7 @@ public class DepositToDvDatasetMetadataMapper {
 
         var version = new DatasetVersion();
         version.setTermsOfAccess(termsOfAccess);
+        version.setFileAccessRequest(true);
         version.setMetadataBlocks(fields);
         version.setFiles(new ArrayList<>());
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromProfileTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromProfileTest.java
@@ -42,7 +42,7 @@ public class CitationMetadataFromProfileTest {
     void CIT001_should_map_title() throws ParserConfigurationException, IOException, SAXException {
         var doc = ddmWithCustomProfileContent("");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getPrimitiveSingleValueField("citation", "title", result))
             .isEqualTo("Title of the dataset");
     }
@@ -53,7 +53,7 @@ public class CitationMetadataFromProfileTest {
             + "<dc:creator>J. Bond</dc:creator>\n"
             + "<dc:creator>D. O'Seven</dc:creator>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getCompoundMultiValueField("citation", AUTHOR, result))
             .extracting(AUTHOR_NAME).extracting("value")
             .hasSameElementsAs(List.of("J. Bond", "D. O'Seven"));
@@ -73,7 +73,7 @@ public class CitationMetadataFromProfileTest {
             + "    </dcx-dai:author>\n"
             + "</dcx-dai:creatorDetails>\n");
         // TODO affiliation, ORCID, ISNI, DAI in AuthorTest
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getCompoundMultiValueField("citation", AUTHOR, result))
             .extracting(AUTHOR_NAME).extracting("value")
             .hasSameElementsAs(List.of("Bond", "O'Seven"));
@@ -93,7 +93,7 @@ public class CitationMetadataFromProfileTest {
             + "    </dcx-dai:organization>\n"
             + "</dcx-dai:creatorDetails>\n");
         // TODO affiliation, ISNI, VIAF in AuthorTest
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getCompoundMultiValueField("citation", AUTHOR, result))
             .extracting(AUTHOR_NAME).extracting("value")
             .hasSameElementsAs(List.of("DANS", "KNAW"));
@@ -106,7 +106,7 @@ public class CitationMetadataFromProfileTest {
             + "<dc:description>dolor sit amet</dc:description>\n"
         );
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getCompoundMultiValueField("citation", DESCRIPTION, result))
             .extracting(DESCRIPTION_VALUE).extracting("value")
             .hasSameElementsAs(List.of("<p>Lorem ipsum.</p>", "<p>dolor sit amet</p>"));
@@ -127,7 +127,7 @@ public class CitationMetadataFromProfileTest {
                 + dcmi("")
                 + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledMultiValueField("citation", "subject", result))
             .hasSameElementsAs(List.of("Astronomy and Astrophysics", "Law", "Mathematical Sciences"));
     }
@@ -136,7 +136,7 @@ public class CitationMetadataFromProfileTest {
     void CIT019_should_map_creation_date() throws ParserConfigurationException, IOException, SAXException {
         var doc = ddmWithCustomProfileContent("<ddm:created>2012-12</ddm:created>");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getPrimitiveSingleValueField("citation", "productionDate", result))
             .isEqualTo("2012-12-01");
     }
@@ -145,7 +145,7 @@ public class CitationMetadataFromProfileTest {
     void CIT025_map_date_available() throws ParserConfigurationException, IOException, SAXException {
         var doc = ddmWithCustomProfileContent("<ddm:available>2014-12</ddm:available>");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getPrimitiveSingleValueField("citation", "distributionDate", result))
             .isEqualTo("2014-12-01");
     }

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapperTest.java
@@ -81,7 +81,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", "otherId:something", "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false, false);
+        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()
@@ -95,7 +95,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", "doi:a/b", "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false, false);
+        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()
@@ -111,7 +111,7 @@ class DepositToDvDatasetMetadataMapperTest {
 
         var vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", null, "otherIdVersion", "swordToken");
 
-        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false, false);
+        var result = mapper.toDataverseDataset(doc, null, null, null, vaultMetadata, false);
         var str = new ObjectMapper()
             .writer()
             .withDefaultPrettyPrinter()

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingIntegrationTest.java
@@ -57,7 +57,7 @@ class MappingIntegrationTest {
             + dcmi("<ddm:description descriptionType=\"Other\">Author from description other</ddm:description>\n")
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         var field = getCompoundMultiValueField("citation", "contributor", result);
         var expected = "Author from description other";
         assertThat(field).extracting(CONTRIBUTOR_NAME).extracting("value")
@@ -82,7 +82,7 @@ class MappingIntegrationTest {
             + dcmi(dcmiContent)
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         var str = toPrettyJsonString(result);
         assertThat(str).containsOnlyOnce("not known description type");
         assertThat(str).containsOnlyOnce("technical description");
@@ -104,7 +104,7 @@ class MappingIntegrationTest {
                 + "    </ddm:dcmiMetadata>\n"
                 + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
 
         var field = (CompoundSingleValueField) result.getDatasetVersion().getMetadataBlocks()
             .get("citation").getFields().stream()
@@ -123,7 +123,7 @@ class MappingIntegrationTest {
             + dcmi("<dct:provenance>copied xml to csv</dct:provenance>\n")
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         var str = toPrettyJsonString(result);
 
         assertThat(str).containsOnlyOnce("copied xml to csv");
@@ -148,7 +148,7 @@ class MappingIntegrationTest {
             + dcmi("")
             + "</ddm:DDM>");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledMultiValueField("citation", SUBJECT, result))
             .isEqualTo(List.of("Astronomy and Astrophysics", "Law", "Mathematical Sciences"));
     }
@@ -165,7 +165,7 @@ class MappingIntegrationTest {
             + dcmi("")
             + "</ddm:DDM>");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledMultiValueField("citation", SUBJECT, result))
             .isEqualTo(List.of("Other"));
     }
@@ -182,7 +182,7 @@ class MappingIntegrationTest {
             + dcmi("<dct:accessRights>Some story</dct:accessRights>\n")
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         var str = toPrettyJsonString(result);
 
         assertThat(str).containsOnlyOnce("<p>Some story</p>");
@@ -190,18 +190,6 @@ class MappingIntegrationTest {
         var field = getCompoundMultiValueField("citation", DESCRIPTION, result);
         assertThat(field).extracting(DESCRIPTION_VALUE).extracting("value")
             .containsOnly("<p>Some story</p>", "<p>Lorem ipsum.</p>");
-        assertThat(result.getDatasetVersion().getTermsOfAccess()).isEqualTo("N/a");
-    }
-
-    @Test
-    void DD_1216_DctAccesRights_maps_to_termsofaccess() throws Exception {
-        var doc = readDocumentFromString(""
-            + "<ddm:DDM " + rootAttributes + ">\n"
-            + minimalDdmProfile()
-            + dcmi("<dct:accessRights>Some story</dct:accessRights>\n")
-            + "</ddm:DDM>\n");
-
-        var result = mapDdmToDataset(doc, true, true);
-        assertThat(result.getDatasetVersion().getTermsOfAccess()).isEqualTo("Some story");
+        assertThat(result.getDatasetVersion().getTermsOfAccess()).isEqualTo("");
     }
 }

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingTestHelper.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/MappingTestHelper.java
@@ -44,7 +44,7 @@ class MappingTestHelper {
         return new XmlReaderImpl().readXmlString(xml);
     }
 
-    static Dataset mapDdmToDataset(Document ddm, boolean filesThatAreAccessibleToNonePresentInDeposit, boolean filesThatAreRestrictedRequestPresentInDeposit) {
+    static Dataset mapDdmToDataset(Document ddm, boolean restrictedFilesPresent) {
         final Set<String> activeMetadataBlocks = Set.of("citation", "dansRights", "dansRelationalMetadata", "dansArchaeologyMetadata", "dansTemporalSpatial", "dansDataVaultMetadata");
         final VaultMetadata vaultMetadata = new VaultMetadata("pid", "bagId", "nbn", "otherId:something", "otherIdVersion", "swordToken");
         final Map<String, String> iso1ToDataverseLanguage = new HashMap<>();
@@ -56,7 +56,7 @@ class MappingTestHelper {
         iso2ToDataverseLanguage.put("ger", "German");
         return new DepositToDvDatasetMetadataMapper(
             true, activeMetadataBlocks, iso1ToDataverseLanguage, iso2ToDataverseLanguage, List.of("Netherlands", "United Kingdom", "Belgium", "Germany")
-        ).toDataverseDataset(ddm, null, null, null, vaultMetadata, filesThatAreAccessibleToNonePresentInDeposit, filesThatAreRestrictedRequestPresentInDeposit);
+        ).toDataverseDataset(ddm, null, null, null, vaultMetadata, restrictedFilesPresent);
     }
 
     static final String rootAttributes = "xmlns:ddm='http://schemas.dans.knaw.nl/dataset/ddm-v2/'\n"

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/RightsMetadataTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/RightsMetadataTest.java
@@ -66,7 +66,7 @@ class RightsMetadataTest {
     @Test
     void RIG000A_should_map_dai_authors() {
 
-        var result = mapDdmToDataset(ddmWithOrganizations, false, false);
+        var result = mapDdmToDataset(ddmWithOrganizations, false);
         assertThat(getPrimitiveMultipleValueField("dansRights", "dansRightsHolder", result))
             .containsOnly("Some org", "Some other org");
     }
@@ -74,7 +74,7 @@ class RightsMetadataTest {
     @Test
     void RIG003_should_collect_languages_from_authors() {
 
-        var result = mapDdmToDataset(ddmWithOrganizations, false, false);
+        var result = mapDdmToDataset(ddmWithOrganizations, false);
         assertThat(getControlledMultiValueField("dansRights", "dansMetadataLanguage", result))
             .containsOnly("Dutch", "German");
     }
@@ -105,7 +105,7 @@ class RightsMetadataTest {
     @Test
     void RIG000B_should_map_organizations() {
 
-        var result = mapDdmToDataset(ddmWithAuthors, false, false);
+        var result = mapDdmToDataset(ddmWithAuthors, false);
         assertThat(getPrimitiveMultipleValueField("dansRights", "dansRightsHolder", result))
             .containsOnly("Example Org", "Another Org");
     }
@@ -113,7 +113,7 @@ class RightsMetadataTest {
     @Test
     void RIG003_should_collect_languages_from_organizations() {
 
-        var result = mapDdmToDataset(ddmWithAuthors, false, false);
+        var result = mapDdmToDataset(ddmWithAuthors, false);
         assertThat(getControlledMultiValueField("dansRights", "dansMetadataLanguage", result))
             .containsOnly("Dutch", "German");
     }
@@ -129,7 +129,7 @@ class RightsMetadataTest {
             + "    </ddm:dcmiMetadata>\n"
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getPrimitiveMultipleValueField("dansRights", RIGHTS_HOLDER, result))
             .containsOnly("James Bond", "Double O'Seven");
     }
@@ -145,7 +145,7 @@ class RightsMetadataTest {
             + "    </ddm:dcmiMetadata>\n"
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledMultiValueField("dansRights", "dansMetadataLanguage", result))
             .containsOnly("Dutch");
     }
@@ -157,7 +157,7 @@ class RightsMetadataTest {
             + minimalDdmProfile()
             + "</ddm:DDM>\n");
         try {
-            mapDdmToDataset(doc, false, false);
+            mapDdmToDataset(doc, false);
         }
         catch (MissingRequiredFieldException e) {
             assertThat(e.getMessage()).containsOnlyOnce("dansRightsHolder");
@@ -173,7 +173,7 @@ class RightsMetadataTest {
             + dcmi("")
             + "</ddm:DDM>\n");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledSingleValueField("dansRights", "dansPersonalDataPresent", result))
             .isEqualTo("Unknown");
     }
@@ -191,7 +191,7 @@ class RightsMetadataTest {
             + dcmi("")
             + "</ddm:DDM>");
 
-        var result = mapDdmToDataset(doc, false, false);
+        var result = mapDdmToDataset(doc, false);
         assertThat(getControlledSingleValueField("dansRights", "dansPersonalDataPresent", result))
             .isEqualTo("Yes");
         // "No" is tested in the PersonalDataTest class


### PR DESCRIPTION
NO JIRA

# Description of changes
Dataverse's `TermsOfUseAndAccessValidator` was giving errors because the terms of access were not always filled in when fileAccessRequests was off. Part of the reason was that updating the metadata by the DatasetUpdater was overwriting termOfAccess with null. See also: https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/41 

The logic that determined whether to allow access requests and whether to set terms of access was also spread out too much.

* Moved the code that determines whether to allow access requests and whether there are restricted files present to the Deposit class for now: 
    * `allowAccessRequests` is only based on the what the deposit knows. The code that actually turns access requests on or off inspects the current state (only in updates of course) to make sure it does not go from off to on. 
    * `restricedFilesPresent` is also based on what the deposit knows, but in this case this is sufficient, because it is only used to decide whether to fill in `dct:accessRights` in `termsOfAccess` or to leave it empty.
* The code that turns access request on or off also checks whether there are termsOfAccess and fills in "N/a" if there are not **and** file access requests are off.
* The new version of `updateMetadata`, which takes a `DatasetVersion` is used to set `fileAccessRequest` and `termsOfAccess` and no longer calls neither the semantic API (for `termsOfAccess`) nor the enable/disable API (for `fileAccessRequest).
* `dd-dans-sword-examples` has been extended so that the revisions example showcase turning `fileAccessRequests` off.

- [x] Merge related PR and release new library version.

# How to test

# Related PRs
https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/41 

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
