### PR TITLE
NO JIRA. Work-around for non-ascii char in replacement file name

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -282,11 +282,13 @@ public class DatasetUpdater extends DatasetEditor {
             log.debug("Replacing file with ID = {}", entry.getKey());
             var fileApi = dataverseClient.file(entry.getKey());
 
-            var meta = new FileMeta();
-            meta.setForceReplace(true);
-            var json = objectMapper.writeValueAsString(meta);
             var wrappedZip = zipFileHandler.wrapIfZipFile(entry.getValue().getPath());
             var file = wrappedZip.orElse(entry.getValue().getPath());
+
+            var meta = new FileMeta();
+            meta.setForceReplace(true);
+            meta.setLabel(file.getFileName().toString());
+            var json = objectMapper.writeValueAsString(meta);
 
             log.debug("Calling replaceFileItem({}, {})", entry.getValue().getPath(), json);
             var result = fileApi.replaceFileItem(


### PR DESCRIPTION
NO JIRA.

# Description of changes
When doing a file replacement, the metadata for the file used to have empty fields, as the metadata of **all** files is updated later in the process anyway. A side effect of this was that the filename from then Content-Disposition header was used to determine the initial filename. In one case the name contained a "`" (back-tick) character. At the Dataverse side this was replaced with a question mark which is a forbidden character for a file label, so Dataverse returned "400 could not add file" (it was a replacement, but anyway...).

Setting the encoding of the Content-Disposition headers seems hard to achieve. See for example [this post](https://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http), although it is a bit old. In any case, we can work around this by setting the label in the replaceFile call, which is what this pull request does.

# Notify

@DANS-KNAW/dataversedans
