### PR TITLE
Removed unused config settings

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -106,14 +106,10 @@ taskEventDatabase:
 validateDansBag:
   baseUrl: 'http://localhost:20330'
   pingUrl: 'http://localhost:20331/ping'
-  connectionTimeoutMs: 10000
-  readTimeoutMs: 30000
   httpClient:
-    # this configures the bag validator client
-    # the important thing is to disable chunked encoding
-    # because it breaks the multipart/form-data headers:
-    timeout: 30000ms
-    connectionTimeout: 10000ms
+    timeout: 5min
+    connectionTimeout: 1min
+    # disable chunked encoding because it breaks the multipart/form-data headers:
     chunkedEncodingEnabled: false
     timeToLive: 1h
     cookiesEnabled: false

--- a/src/main/java/nl/knaw/dans/ingest/core/config/ValidateDansBagConfig.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/config/ValidateDansBagConfig.java
@@ -16,60 +16,23 @@
 package nl.knaw.dans.ingest.core.config;
 
 import io.dropwizard.client.JerseyClientConfiguration;
+import lombok.Data;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 
+@Data
 public class ValidateDansBagConfig {
+    @NotNull
+    @Valid
     private URI baseUrl;
 
+    @NotNull
+    @Valid
     private URI pingUrl;
 
-    private int connectionTimeoutMs;
     @Valid
     @NotNull
     private JerseyClientConfiguration httpClient = new JerseyClientConfiguration();
-
-    public JerseyClientConfiguration getHttpClient() {
-        return httpClient;
-    }
-
-    public void setHttpClient(JerseyClientConfiguration jerseyClient) {
-        this.httpClient = jerseyClient;
-    }
-
-    private int readTimeoutMs;
-
-    public URI getBaseUrl() {
-        return baseUrl;
-    }
-
-    public void setBaseUrl(URI baseUrl) {
-        this.baseUrl = baseUrl;
-    }
-
-    public URI getPingUrl() {
-        return pingUrl;
-    }
-
-    public void setPingUrl(URI pingUrl) {
-        this.pingUrl = pingUrl;
-    }
-
-    public int getConnectionTimeoutMs() {
-        return connectionTimeoutMs;
-    }
-
-    public void setConnectionTimeoutMs(int connectionTimeoutMs) {
-        this.connectionTimeoutMs = connectionTimeoutMs;
-    }
-
-    public int getReadTimeoutMs() {
-        return readTimeoutMs;
-    }
-
-    public void setReadTimeoutMs(int readTimeoutMs) {
-        this.readTimeoutMs = readTimeoutMs;
-    }
 }

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -86,11 +86,9 @@ taskEventDatabase:
 validateDansBag:
   baseUrl: 'http://localhost:20330'
   pingUrl: 'http://localhost:20331/ping'
-  connectionTimeoutMs: 10000
-  readTimeoutMs: 30000
   httpClient:
-    timeout: 30000ms
-    connectionTimeout: 10000ms
+    timeout: 5min
+    connectionTimeout: 1min
     chunkedEncodingEnabled: false
     timeToLive: 1h
     cookiesEnabled: false

--- a/src/test/resources/unit-test-config.yml
+++ b/src/test/resources/unit-test-config.yml
@@ -79,11 +79,9 @@ taskEventDatabase:
 validateDansBag:
   baseUrl: 'http://localhost:20330'
   pingUrl: 'http://localhost:20331/ping'
-  connectionTimeoutMs: 10000
-  readTimeoutMs: 30000
   httpClient:
-    timeout: 30000ms
-    connectionTimeout: 10000ms
+    timeout: 5min
+    connectionTimeout: 1min
     chunkedEncodingEnabled: false
     timeToLive: 1h
     cookiesEnabled: false


### PR DESCRIPTION
NO JIRA

# Description of changes
* The configuration block `validateDansBag` contained two settings that were not used: `connectionTimeoutMs`, `readTimeoutMs`.   
  The nested `httpClient` contains parameters that control these timeouts. Removed the redundant settings.
* Tried out if Lombok will work together with DropWizard by lombokifying the `ValidateDansBagConfig` class.

# Notify

@DANS-KNAW/dataversedans
