### PR TITLE
DD-1338 API key per ingest area

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
@@ -139,9 +139,8 @@ public class DdIngestFlowApplication extends Application<DdIngestFlowConfigurati
             enqueuingService
         );
 
-        environment.healthChecks().register("DataverseAutoIngestArea", new DataverseHealthCheck(dataverseClientAutoIngestArea));
-        environment.healthChecks().register("DataverseMigrationArea", new DataverseHealthCheck(dataverseClientMigrationArea));
-        environment.healthChecks().register("DataverseImportArea", new DataverseHealthCheck(dataverseClientImportArea));
+        // Use the default configuration for the health checks. No API key is required.
+        environment.healthChecks().register("Dataverse", new DataverseHealthCheck(configuration.getDataverse().build()));
         environment.healthChecks().register("DansBagValidator", new DansBagValidatorHealthCheck(dansBagValidator));
 
         environment.lifecycle().manage(autoIngestArea);
@@ -154,7 +153,9 @@ public class DdIngestFlowApplication extends Application<DdIngestFlowConfigurati
 
     private static DataverseClient getDataverseClient(DdIngestFlowConfiguration configuration, IngestAreaConfig ingestAreaConfig) {
         final var dataverseClientFactory = configuration.getDataverse();
-        dataverseClientFactory.setApiKey(ingestAreaConfig.getApiKey());
+        if (ingestAreaConfig.getApiKey() != null) {
+            dataverseClientFactory.setApiKey(ingestAreaConfig.getApiKey());
+        }
         return dataverseClientFactory.build();
     }
 }


### PR DESCRIPTION
Fixes DD-1338

# Description of changes
Amends #97 removing the separate health check for each dataverse client. The health check only accesses the root dataverse anyway, so there is no added value in trying it with different API keys. No API key is required at all.

Also implemented defaulting to the API key configured on the `dataverse` block in the config file, which was missing.

# How to test

# Related PRs

* #97 

# Notify

@DANS-KNAW/dataversedans
