### PR TITLE
DD-1338: apiKey per area: single dataverse health check

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -28,14 +28,17 @@ server:
 
 ingestFlow:
   import:
+    apiKey: 'changeme' # overrides the default
     inbox: /var/opt/dans.knaw.nl/tmp/import/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/import/outbox
 
   migration:
+    apiKey: 'changeme' # overrides the default
     inbox: /var/opt/dans.knaw.nl/tmp/migration/deposits
     outbox: /var/opt/dans.knaw.nl/tmp/migration/out
 
   autoIngest:
+    apiKey: 'changeme' # overrides the default
     inbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/inbox
     outbox: /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox
     depositorRole: swordupdater

--- a/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
+++ b/src/main/java/nl/knaw/dans/ingest/DdIngestFlowApplication.java
@@ -139,9 +139,7 @@ public class DdIngestFlowApplication extends Application<DdIngestFlowConfigurati
             enqueuingService
         );
 
-        environment.healthChecks().register("DataverseAutoIngestArea", new DataverseHealthCheck(dataverseClientAutoIngestArea));
-        environment.healthChecks().register("DataverseMigrationArea", new DataverseHealthCheck(dataverseClientMigrationArea));
-        environment.healthChecks().register("DataverseImportArea", new DataverseHealthCheck(dataverseClientImportArea));
+        environment.healthChecks().register("Dataverse", new DataverseHealthCheck(dataverseClientAutoIngestArea));
         environment.healthChecks().register("DansBagValidator", new DansBagValidatorHealthCheck(dansBagValidator));
 
         environment.lifecycle().manage(autoIngestArea);

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -13,14 +13,17 @@ server:
 
 ingestFlow:
   import:
+    apiKey: 'changeme' # overrides the default
     inbox: data/import/inbox
     outbox: data/import/outbox
 
   migration:
+    apiKey: 'changeme' # overrides the default
     inbox: data/migration/deposits
     outbox: data/migration/out
 
   autoIngest:
+    apiKey: 'changeme' # overrides the default
     inbox: data/auto-ingest/inbox
     outbox: data/auto-ingest/outbox
     authorization:
@@ -60,7 +63,7 @@ ingestFlow:
 #
 dataverse:
   baseUrl: 'http://dar.dans.knaw.nl:8080'
-  apiKey: 'changeme'
+  apiKey: 'changeme' # define override value per ingest area
   unblockKey: 's3kretKey'
   awaitLockStateMaxNumberOfRetries: 30
   awaitLockStateMillisecondsBetweenRetries: 500


### PR DESCRIPTION
Fixes DD-1338: apiKey per area: single dataverse health check

# Description of changes

# How to test
* [x] ...?

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
