### PR TITLE
DD-1442 Ingest-problems Dataverse v5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-ingest-flow</artifactId>
-    <version>0.50.1-SNAPSHOT</version>
+    <version>0.51.0-SNAPSHOT</version>
 
     <name>DD Ingest Flow</name>
     <url>https://github.com/DANS-KNAW/dd-ingest-flow</url>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -77,6 +77,7 @@ ingestFlow:
     # user001: The Organization Name
 
   deduplicate: true
+  deleteDraftOnFailure: true
   zipWrappingTempDir: /var/opt/dans.knaw.nl/tmp/zip-wrapping
   mappingDefsDir: /etc/opt/dans.knaw.nl/dd-ingest-flow
   taskQueue:

--- a/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/config/IngestFlowConfig.java
@@ -80,6 +80,8 @@ public class IngestFlowConfig {
     @Valid
     private String vaultMetadataKey;
 
+    private boolean deleteDraftOnFailure;
+
     public IngestAreaConfig getImportConfig() {
         return importConfig;
     }
@@ -214,5 +216,13 @@ public class IngestFlowConfig {
 
     public void setVaultMetadataKey(String vaultMetadataKey) {
         this.vaultMetadataKey = vaultMetadataKey;
+    }
+
+    public void setDeleteDraftOnFailure(boolean deleteDraftOnFailure) {
+        this.deleteDraftOnFailure = deleteDraftOnFailure;
+    }
+
+    public boolean isDeleteDraftOnFailure() {
+        return deleteDraftOnFailure;
     }
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
@@ -53,8 +53,8 @@ public class DatasetCreator extends DatasetEditor {
         ZipFileHandler zipFileHandler,
         String depositorRole,
         DatasetService datasetService,
-        String vaultMetadataKey
-    ) {
+        String vaultMetadataKey,
+        boolean deleteDraftOnFailure) {
         super(
             isMigration,
             dataset,
@@ -62,7 +62,8 @@ public class DatasetCreator extends DatasetEditor {
             supportedLicenses,
             fileExclusionPattern,
             zipFileHandler, objectMapper, datasetService,
-            vaultMetadataKey);
+            vaultMetadataKey,
+            deleteDraftOnFailure);
 
         this.depositorRole = depositorRole;
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactory.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactory.java
@@ -47,6 +47,8 @@ public class DepositIngestTaskFactory {
     private final DepositorAuthorizationValidator depositorAuthorizationValidator;
     private final String vaultMetadataKey;
 
+    private final boolean deleteDraftOnFailure;
+
     public DepositIngestTaskFactory(
         boolean isMigration,
         String depositorRole,
@@ -70,6 +72,7 @@ public class DepositIngestTaskFactory {
         this.blockedTargetService = blockedTargetService;
         this.depositorAuthorizationValidator = depositorAuthorizationValidator;
         this.vaultMetadataKey = vaultMetadataKey;
+        this.deleteDraftOnFailure = ingestFlowConfig.isDeleteDraftOnFailure();
     }
 
     public DepositIngestTask createIngestTask(Path depositDir, Path outboxDir, EventWriter eventWriter) throws InvalidDepositException, IOException {
@@ -129,7 +132,8 @@ public class DepositIngestTaskFactory {
                 datasetService,
                 blockedTargetService,
                 depositorAuthorizationValidator,
-                vaultMetadataKey
+                vaultMetadataKey,
+                deleteDraftOnFailure
             );
         }
         else {
@@ -147,7 +151,8 @@ public class DepositIngestTaskFactory {
                 datasetService,
                 blockedTargetService,
                 depositorAuthorizationValidator,
-                vaultMetadataKey
+                vaultMetadataKey,
+                deleteDraftOnFailure
             );
         }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElement.java
@@ -135,7 +135,7 @@ public class FileElement extends Base {
         if (isMigration) {
 
             // FIL002A
-            getChildNodes(node, "//afm:keyvaluepair")
+            getChildNodes(node, "afm:keyvaluepair")
                 .forEach(n -> {
                     var key = getChildNode(n, "afm:key")
                         .map(Node::getTextContent)

--- a/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
@@ -114,7 +114,8 @@ public class DepositStartImportTaskWrapperTest {
             datasetService,
             blockedTargetService,
             depositorAuthorizationValidator,
-            vaultMetadataKey
+            vaultMetadataKey,
+            false
         );
     }
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/DatasetEditorTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/DatasetEditorTest.java
@@ -59,7 +59,7 @@ public class DatasetEditorTest extends BaseTest {
     private DatasetEditor createDatasetEditor(Deposit deposit, final boolean isMigration, final Pattern fileExclusionPattern, final List<URI> supportedLicenses) {
         var dataverseService = new DataverseServiceImpl(Mockito.mock(DataverseClient.class), 1, 1);
         var zipFileHandler = new ZipFileHandler(testDir.resolve("tmp"));
-        return new DatasetEditor(isMigration, null, deposit, supportedLicenses, fileExclusionPattern, zipFileHandler, null, dataverseService, null) {
+        return new DatasetEditor(isMigration, null, deposit, supportedLicenses, fileExclusionPattern, zipFileHandler, null, dataverseService, null, false) {
 
             @Override
             public String performEdit() {

--- a/src/test/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskTest.java
@@ -92,20 +92,21 @@ public class DepositIngestTaskTest {
                 .thenReturn(deposit);
 
         return new DepositIngestTask(
-                depositToDvDatasetMetadataMapperFactory,
-                depositLocation,
-                "dummy",
-                null,
-                zipFileHandler,
-                List.of(),
-                dansBagValidator,
-                Path.of("outbox"),
-                eventWriter,
-                depositManager,
-                datasetService,
-                blockedTargetService,
-                depositorAuthorizationValidator,
-                "dummy"
+            depositToDvDatasetMetadataMapperFactory,
+            depositLocation,
+            "dummy",
+            null,
+            zipFileHandler,
+            List.of(),
+            dansBagValidator,
+            Path.of("outbox"),
+            eventWriter,
+            depositManager,
+            datasetService,
+            blockedTargetService,
+            depositorAuthorizationValidator,
+            "dummy",
+            false
         );
     }
 

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElementTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElementTest.java
@@ -108,7 +108,8 @@ class FileElementTest extends BaseTest {
             + "</file>", ns));
 
         var result = FileElement.toFileMeta(doc.getDocumentElement(), defaultRestrict, isMigration);
-        assertEquals("original_filepath: \"leeg#.txt\"; description: \"Empty file\"; title: \"original/archival file name\"; time_period: \"Classical\"; hardware: \"Hardware\"", result.getDescription());
+        assertEquals("original_filepath: \"leeg#.txt\"; description: \"Empty file\"; title: \"original/archival file name\"; time_period: \"Classical\"; hardware: \"Hardware\"",
+            result.getDescription());
     }
 
     @Test
@@ -167,6 +168,36 @@ class FileElementTest extends BaseTest {
         assertTrue(result.getRestricted());
         assertEquals("othmat_codebook: \"FOTOBEST.csv; FOTOLST.csv\"; FOTONR: \"3\"", result.getDescription()); // FIL002A/B (migration only)
     }
+
+//    @Test
+//    void toFileMeta_should_only_use_keyvalue_pairs_of_current_file() throws Exception {
+//        String filePath1 = "data/this/is/the/directory/label/leeg.txt";
+//        String filePath2 = "data/this/is/the/directory/label/leeg2.txt";
+//        var doc = readDocumentFromString(String.format(""
+//            + "<files>"
+//            + "<file filepath='%s' %s>"
+//            + "    <dcterms:othmat_codebook>FOTOBEST.csv; FOTOLST.csv</dcterms:othmat_codebook>"
+//            + "    <afm:keyvaluepair>"
+//            + "        <afm:key>FOTONR</afm:key>"
+//            + "        <afm:value>3</afm:value>"
+//            + "    </afm:keyvaluepair>"
+//            + "</file>"
+//            + "  <file filepath='%s' %s>"
+//            + "    <dcterms:othmat_codebook>FOTOBEST.csv; FOTOLST.csv</dcterms:othmat_codebook>"
+//            + "    <afm:keyvaluepair>"
+//            + "        <afm:key>FOTONR</afm:key>"
+//            + "        <afm:value>3</afm:value>"
+//            + "    </afm:keyvaluepair>"
+//            + "</file>"
+//            + "</files>", filePath1, ns, filePath2, ns)
+//        );
+//
+//        var result = FileElement.toFileMeta(doc.get, defaultRestrict, isMigration);
+//        assertEquals("leeg.txt", result.getLabel());
+//        assertEquals("this/is/the/directory/label", result.getDirectoryLabel());
+//        assertTrue(result.getRestricted());
+//        assertEquals("othmat_codebook: \"FOTOBEST.csv; FOTOLST.csv\"; FOTONR: \"3\"", result.getDescription()); // FIL002A/B (migration only)
+//    }
 
     @Test
     void toFileMeta_should_include_original_filepath_if_directoryLabel_or_label_change_during_sanitation() throws Exception {

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElementTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/FileElementTest.java
@@ -108,8 +108,7 @@ class FileElementTest extends BaseTest {
             + "</file>", ns));
 
         var result = FileElement.toFileMeta(doc.getDocumentElement(), defaultRestrict, isMigration);
-        assertEquals("original_filepath: \"leeg#.txt\"; description: \"Empty file\"; title: \"original/archival file name\"; time_period: \"Classical\"; hardware: \"Hardware\"",
-            result.getDescription());
+        assertEquals("original_filepath: \"leeg#.txt\"; description: \"Empty file\"; title: \"original/archival file name\"; time_period: \"Classical\"; hardware: \"Hardware\"", result.getDescription());
     }
 
     @Test
@@ -168,36 +167,6 @@ class FileElementTest extends BaseTest {
         assertTrue(result.getRestricted());
         assertEquals("othmat_codebook: \"FOTOBEST.csv; FOTOLST.csv\"; FOTONR: \"3\"", result.getDescription()); // FIL002A/B (migration only)
     }
-
-//    @Test
-//    void toFileMeta_should_only_use_keyvalue_pairs_of_current_file() throws Exception {
-//        String filePath1 = "data/this/is/the/directory/label/leeg.txt";
-//        String filePath2 = "data/this/is/the/directory/label/leeg2.txt";
-//        var doc = readDocumentFromString(String.format(""
-//            + "<files>"
-//            + "<file filepath='%s' %s>"
-//            + "    <dcterms:othmat_codebook>FOTOBEST.csv; FOTOLST.csv</dcterms:othmat_codebook>"
-//            + "    <afm:keyvaluepair>"
-//            + "        <afm:key>FOTONR</afm:key>"
-//            + "        <afm:value>3</afm:value>"
-//            + "    </afm:keyvaluepair>"
-//            + "</file>"
-//            + "  <file filepath='%s' %s>"
-//            + "    <dcterms:othmat_codebook>FOTOBEST.csv; FOTOLST.csv</dcterms:othmat_codebook>"
-//            + "    <afm:keyvaluepair>"
-//            + "        <afm:key>FOTONR</afm:key>"
-//            + "        <afm:value>3</afm:value>"
-//            + "    </afm:keyvaluepair>"
-//            + "</file>"
-//            + "</files>", filePath1, ns, filePath2, ns)
-//        );
-//
-//        var result = FileElement.toFileMeta(doc.get, defaultRestrict, isMigration);
-//        assertEquals("leeg.txt", result.getLabel());
-//        assertEquals("this/is/the/directory/label", result.getDirectoryLabel());
-//        assertTrue(result.getRestricted());
-//        assertEquals("othmat_codebook: \"FOTOBEST.csv; FOTOLST.csv\"; FOTONR: \"3\"", result.getDescription()); // FIL002A/B (migration only)
-//    }
 
     @Test
     void toFileMeta_should_include_original_filepath_if_directoryLabel_or_label_change_during_sanitation() throws Exception {


### PR DESCRIPTION
Fixes DD-1442

# Description of changes
In reality DD-1442 will have to be fixed in Dataverse, but I am classifying this PR under DD-1442 because the fixes in it were found while investigating and testing DD-1442. 

* Made `deleteDraftOnFailure` a configuration option. During testing you may want to keep the draft resulting from a failed deposit around, in order to be able to analyze the problem better.
* Fixed a problem in `FileElement.toFileMeta` which caused huge descriptions when there where `keyvaluepair` elements.
* Saving the DOI to `deposit.properties` prefixed it with `doi:`, in Dataverse style. However, this caused multiple `doi:` prefixes when retrying the same deposits. `identfier.doi` is now stored without the prefix, the way it is also found in a migration deposit. Furthermore, it is only stored in a non-migration deposit now.
* Changed the override of `postPublication` in `MigrationDepositTask`. Previously, it was a no-op, but now it does wait for the dataset to change to RELEASED state, just like for a SWORD2 deposit. It will wait 45 minutes by default. Sometimes it takes a long time (up to 15 minutes?) for a dataset to finally change its state, even after Dataverse has logged that is was published successfully. Not waiting, will make subsequent update-deposits fail because these expect to find the dataset to be updated in RELEASED state, and generally, it is confusing to have draft datasets that correspond to deposits in "processed" (i.e. successfully processed deposits).

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
