### PR TITLE
DD-1461. Fixed error in expression + added constants for often used expression prefixes

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositFileListerImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositFileListerImpl.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static nl.knaw.dans.ingest.core.service.XPathConstants.FILES_FILE;
+
 public class DepositFileListerImpl implements DepositFileLister {
     @Override
     public List<DepositFile> getDepositFiles(Deposit deposit) throws IOException {
@@ -39,7 +41,7 @@ public class DepositFileListerImpl implements DepositFileLister {
         var filePathToSha1 = ManifestHelperImpl.getFilePathToSha1(bag);
         var originalFilePathMappings = getOriginalFilePathMapping(bagDir);
 
-        return XPathEvaluator.nodes(deposit.getFilesXml(), "/files:files/files:file")
+        return XPathEvaluator.nodes(deposit.getFilesXml(), FILES_FILE)
             .map(node -> {
                 var filePath = Optional.ofNullable(node.getAttributes().getNamedItem("filepath"))
                     .map(Node::getTextContent)

--- a/src/main/java/nl/knaw/dans/ingest/core/domain/Deposit.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/domain/Deposit.java
@@ -30,6 +30,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static nl.knaw.dans.ingest.core.service.XPathConstants.DDM_PROFILE;
+import static nl.knaw.dans.ingest.core.service.XPathConstants.FILES_FILE;
 import static nl.knaw.dans.ingest.core.service.XmlNamespaces.NAMESPACE_XSI;
 
 @Data
@@ -108,13 +110,13 @@ public class Deposit {
      * @return whether this deposit allows access requests
      */
     public boolean allowAccessRequests() {
-        var accessRightsNode = XPathEvaluator.nodes(ddm, "/ddm:DDM/ddm:profile/ddm:accessRights")
+        var accessRightsNode = XPathEvaluator.nodes(ddm, DDM_PROFILE + "/ddm:accessRights")
             .findFirst()
             .orElseThrow();
 
         var isNoAccessDataset = "NO_ACCESS".equals(accessRightsNode.getTextContent().trim());
         var accessibleToNoneFilesPresent = XPathEvaluator
-            .strings(filesXml, "/files:files/files:file/files:accessibleToRights")
+            .strings(filesXml, FILES_FILE + "/files:accessibleToRights")
             .map(String::trim)
             .anyMatch("NONE"::equals);
 
@@ -124,7 +126,7 @@ public class Deposit {
     public boolean restrictedFilesPresent() {
         var numberOfFiles = files.size();
         var explicitAccessibleToValues = XPathEvaluator
-            .strings(filesXml, "/files:files/files:file/files:accessibleToRights")
+            .strings(filesXml, FILES_FILE + "/files:accessibleToRights")
             .map(String::trim).collect(Collectors.toList());
         var explicitlyRestrictedFilesPresent = explicitAccessibleToValues.stream()
             .anyMatch(a -> !"ANONYMOUS".equals(a));

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
@@ -52,6 +52,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static nl.knaw.dans.ingest.core.service.XPathConstants.DDM_DCMI_METADATA;
+
 @Slf4j
 public abstract class DatasetEditor {
 
@@ -165,7 +167,7 @@ public abstract class DatasetEditor {
     }
 
     protected String getLicense(Node node) {
-        return XPathEvaluator.nodes(node, "/ddm:DDM/ddm:dcmiMetadata/dcterms:license")
+        return XPathEvaluator.nodes(node, DDM_DCMI_METADATA + "/dcterms:license")
             .filter(License::isLicenseUri)
             .findFirst()
             .map(n -> License.getLicenseUri(supportedLicenses, n))

--- a/src/main/java/nl/knaw/dans/ingest/core/service/XPathConstants.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/XPathConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ingest.core.service;
+
+public interface XPathConstants {
+    String DDM_PROFILE = "/ddm:DDM/ddm:profile";
+    String DDM_DCMI_METADATA = "/ddm:DDM/ddm:dcmiMetadata";
+    String FILES_FILE = "/files:files/files:file";
+}

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -396,7 +396,7 @@ public class DepositToDvDatasetMetadataMapper {
     }
 
     Stream<String> getLanguageAttributes(Document ddm) {
-        return XPathEvaluator.strings(ddm, DDM_PROFILE + "//@xml:lang | " + DDM_DCMI_METADATA + "//@xml:lang");
+        return XPathEvaluator.strings(ddm, DDM_PROFILE + "//@xml:lang", DDM_DCMI_METADATA + "//@xml:lang");
     }
 
     Stream<Node> getContributorDetailsOrganizations(Document ddm) {
@@ -410,7 +410,7 @@ public class DepositToDvDatasetMetadataMapper {
     }
 
     Stream<Node> getContributorDetails(Document ddm) {
-        return XPathEvaluator.nodes(ddm, DDM_DCMI_METADATA + "/dcx-dai:contributorDetails[dcx-dai:author] | " + DDM_DCMI_METADATA + "/dcx-dai:contributorDetails[dcx-dai:organization]");
+        return XPathEvaluator.nodes(ddm, DDM_DCMI_METADATA + "/dcx-dai:contributorDetails[dcx-dai:author]", DDM_DCMI_METADATA + "/dcx-dai:contributorDetails[dcx-dai:organization]");
     }
 
     Stream<Node> getCreated(Document ddm) {

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/mapping/RelationTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.RELATION_TEXT;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.RELATION_TYPE;
 import static nl.knaw.dans.ingest.core.service.DepositDatasetFieldNames.RELATION_URI;
+import static nl.knaw.dans.ingest.core.service.XPathConstants.DDM_DCMI_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RelationTest extends BaseTest {
@@ -46,7 +47,7 @@ class RelationTest extends BaseTest {
                 + "</ddm:DDM>\n");
 
         var builder = new CompoundFieldBuilder("", true);
-        XPathEvaluator.nodes(doc, "/ddm:DDM/ddm:dcmiMetadata//*")
+        XPathEvaluator.nodes(doc, DDM_DCMI_METADATA + "//*")
             .filter(Relation::isRelation)
             .forEach(item -> {
                 Relation.toRelationObject.build(builder, item);


### PR DESCRIPTION
Fixes DD-1461

# Description of changes
I forgot the `ddm` prefix for `ddm:dcmiMetadata` here: https://github.com/DANS-KNAW/dd-ingest-flow/compare/master...janvanmansum:dd-ingest-flow:DD-1461b?expand=1#diff-745b51a7500fd6ed9124c8d4d697b0e785d98e5755aa155d3581807a5c303536L429 which was a really hard-to-spot bug. Fixed this and also made the often-used expression prefixed `/ddm:DDM/profile` and `/ddm:DDM/ddm:dcmiMetadata` into constants to prevent this from happening again.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
