### PR TITLE
DD-1445 Add check on InReview status for update-deposits

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/dataverse/DatasetService.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/dataverse/DatasetService.java
@@ -55,4 +55,6 @@ public interface DatasetService {
     List<URI> getLicenses() throws IOException, DataverseException;
 
     void submitForReview(String persitentId) throws IOException, DataverseException;
+
+    boolean isDatasetInReview(String persitentId) throws IOException, DataverseException;
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/dataverse/DataverseServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/dataverse/DataverseServiceImpl.java
@@ -218,4 +218,10 @@ public class DataverseServiceImpl implements DatasetService {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
     }
+
+    @Override
+    public boolean isDatasetInReview(String persistentId) throws IOException, DataverseException {
+        var r = dataverseClient.dataset(persistentId).getLocks();
+        return r.getData().stream().anyMatch(l -> l.getLockType().equals("InReview"));
+    }
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -240,6 +240,12 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
                     "Dataset %s is not allowed to be updated by user %s", deposit.getDataverseDoi(), deposit.getDepositorUserId()
                 ));
             }
+            log.debug("Checking if dataset {} is in review ...", dataverseDoi);
+            if (isDatasetInReview()) {
+                throw new RejectedDepositException(deposit, String.format(
+                    "Dataset %s is in review and cannot be updated", deposit.getDataverseDoi()
+                ));
+            }
             log.debug("Checking if dataset {} is blocked ...", dataverseDoi);
             checkBlockedTarget();
         }
@@ -284,6 +290,12 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
             throw new FailedDepositException(deposit, e.getMessage());
         }
     }
+
+   boolean isDatasetInReview() throws IOException, DataverseException {
+        var deposit = getDeposit();
+        var target = deposit.getDataverseDoi();
+        return datasetService.isDatasetInReview(target);
+   }
 
     void checkBlockedTarget() throws TargetBlockedException {
         var deposit = getDeposit();


### PR DESCRIPTION
Fixes DD-1445

# Description of changes
Now that datasets deposited through SWORD2 may be submitted for review, update-deposits need to check that the targeted dataset is not In Review before proceeding.


# Notify

@DANS-KNAW/dataversedans
