### PR TITLE
DD-1490 CIT025B date of deposit for new sword deposit.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: adopt-openj9
-          java-version: 11
+          java-version: 17
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Install dependencies
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       - name: Run tests and collect coverage

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -95,6 +95,17 @@ public class DatasetUpdater extends DatasetEditor {
                         // if fileAccessRequest ends up false, Dataverse requires termsOfAccess to be filled in.
                         (fileAccessRequest ? "" : "N/a"));
                 }
+
+                if (!isMigration) {
+                    // CIT025B
+                    // Copy the dateOfDeposit from the latest version. We make an exception for migration, because the dateOfDeposit is taken
+                    // from the AMD. It should not actually make a difference though.
+                    latestVersion.getMetadataBlocks().get("citation").getFields().stream()
+                        .filter(field -> field.getTypeName().equals("dateOfDeposit"))
+                        .findFirst()
+                        .ifPresent(field -> datasetVersion.getMetadataBlocks().get("citation").getFields().add(field));
+                }
+
                 var keyMap = new HashMap<String, String>(singletonMap("dansDataVaultMetadata", vaultMetadataKey));
                 api.updateMetadata(datasetVersion, keyMap);
                 api.awaitUnlock();

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTask.java
@@ -39,6 +39,9 @@ import nl.knaw.dans.lib.dataverse.model.dataset.Dataset;
 import nl.knaw.dans.lib.dataverse.model.user.AuthenticatedUser;
 import nl.knaw.dans.validatedansbag.client.api.ValidateCommandDto;
 import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +56,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class DepositIngestTask implements TargetedTask, Comparable<DepositIngestTask> {
-
+    private static final DateTimeFormatter yyyymmddPattern = DateTimeFormat.forPattern("YYYY-MM-dd");
     private static final Logger log = LoggerFactory.getLogger(DepositIngestTask.class);
     protected final String depositorRole;
     protected final Pattern fileExclusionPattern;
@@ -465,7 +468,12 @@ public class DepositIngestTask implements TargetedTask, Comparable<DepositIngest
     }
 
     Optional<String> getDateOfDeposit() {
-        return Optional.empty();
+        if (deposit.isUpdate()) {
+            return Optional.empty(); // See for implementation CIT025B in DatasetUpdater
+        }
+        else {
+            return Optional.of(yyyymmddPattern.print(DateTime.now())); // CIT025B
+        }
     }
 
     Optional<AuthenticatedUser> getDatasetContact() {

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -178,7 +178,9 @@ public class DepositToDvDatasetMetadataMapper {
             if (isMigration) {
                 citationFields.addNotesText(getProvenance(ddm)); // CIT017A
                 citationFields.addContributors(getDcmiDdmDescriptions(ddm).filter(Description::hasDescriptionTypeOther), Contributor.toContributorValueObject); // CIT021A
-                citationFields.addDateOfDeposit(dateOfDeposit); // CIT025A
+            }
+            if (dateOfDeposit != null) {
+                citationFields.addDateOfDeposit(dateOfDeposit); // CIT025A and CIT025B (first dataset versions)
             }
             citationFields.addDatesOfCollection(getDatesOfCollection(ddm)
                 .filter(DatesOfCollection::isValidDatesOfCollectionPattern), DatesOfCollection.toDateOfCollectionValue); // CIT026


### PR DESCRIPTION
Fixes DD-1490

# Description of changes
* For new non-migration datasets the `dateOfDeposit` is set to the date of today.
* For update-deposits, the `dateOfDeposit` is copied from the previous version. (It is not inherited automatically, as the update code overwrites the complete dataset metadata.)

# How to test
Deploy to `dev_archaeology`, then in `dd-dans-sword2-examples`:
```
./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/all-mappings
```
This adds a dataset. Verify that the deposit date is set to the current date.

Now change the deposit date in the database:
```
vagrant ssh
psql -U dvnuser dvndb # pw dvnsecret
select * from datasetfieldvalue where value = '<current-date>'; # e.g. 2024-01-25
```
This should give you only one row in an empty base box. If so, you can be sure that this is the dateOfDeposit. Update it to point to a date in the past. Check in the UI that the change is visible, then:
```
./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/audiences-sha256 urn:uuid:<uuid-part-of-sword-token>
```

Verify that the deposit date in the second version is the same as in the first.



# Related PRs
* Replaces #121 

# Notify

@DANS-KNAW/core-systems
