### PR TITLE
DD-1539 Get 'Created' timestamp from deposit.properties instead of bag-info.txt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.2.1</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>dd-ingest-flow</artifactId>

--- a/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImpl.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.ingest.core.deposit;
 import gov.loc.repository.bagit.domain.Metadata;
 import gov.loc.repository.bagit.exceptions.InvalidBagitFileFormatException;
 import gov.loc.repository.bagit.exceptions.UnparsableVersionException;
+import lombok.AllArgsConstructor;
 import nl.knaw.dans.ingest.core.domain.DepositLocation;
 import nl.knaw.dans.ingest.core.exception.InvalidDepositException;
 import nl.knaw.dans.ingest.core.exception.MissingTargetException;
@@ -32,23 +33,14 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
+@AllArgsConstructor
 public class DepositLocationReaderImpl implements DepositLocationReader {
-    private final BagDirResolver bagDirResolver;
-
     private final BagDataManager bagDataManager;
-
-    public DepositLocationReaderImpl(BagDirResolver bagDirResolver, BagDataManager bagDataManager) {
-        this.bagDirResolver = bagDirResolver;
-        this.bagDataManager = bagDataManager;
-    }
 
     @Override
     public DepositLocation readDepositLocation(Path depositDir) throws InvalidDepositException, IOException {
-        var bagDir = bagDirResolver.getBagDir(depositDir);
-
         try {
             var properties = bagDataManager.readDepositProperties(depositDir);
-            var bagInfo = bagDataManager.readBagMetadata(bagDir);
             var depositId = getDepositId(depositDir);
             var target = getTarget(properties);
             var created = getCreated(properties);
@@ -60,9 +52,6 @@ public class DepositLocationReaderImpl implements DepositLocationReader {
         }
         catch (MissingTargetException e) {
             throw new InvalidDepositException(e.getMessage(), e);
-        }
-        catch (UnparsableVersionException | InvalidBagitFileFormatException | IOException e) {
-            throw new InvalidDepositException("BagIt file(s) could not be read", e);
         }
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImpl.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImpl.java
@@ -51,7 +51,7 @@ public class DepositLocationReaderImpl implements DepositLocationReader {
             var bagInfo = bagDataManager.readBagMetadata(bagDir);
             var depositId = getDepositId(depositDir);
             var target = getTarget(properties);
-            var created = getCreated(bagInfo);
+            var created = getCreated(properties);
 
             return new DepositLocation(depositDir, target, depositId.toString(), created);
         }
@@ -95,19 +95,14 @@ public class DepositLocationReaderImpl implements DepositLocationReader {
         }
     }
 
-    OffsetDateTime getCreated(Metadata bagInfo) throws InvalidDepositException {
+    OffsetDateTime getCreated(Configuration properties) throws InvalidDepositException {
         try {
-            // the created date comes from bag-info.txt, with the Created property
-            var createdItems = bagInfo.get("created");
-
-            if (createdItems.size() < 1) {
-                throw new InvalidDepositException("Missing 'created' property in bag-info.txt");
-            }
-            else if (createdItems.size() > 1) {
-                throw new InvalidDepositException("Value 'created' should contain exactly 1 value in bag; " + createdItems.size() + " found");
+            var created = properties.getString("creation.timestamp");
+            if (StringUtils.isBlank(created)) {
+                throw new InvalidDepositException("No creation timestamp found in deposit");
             }
 
-            return OffsetDateTime.parse(createdItems.get(0));
+            return OffsetDateTime.parse(created);
         }
         catch (DateTimeParseException e) {
             throw new InvalidDepositException("Error while parsing date", e);

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactoryBuilder.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DepositIngestTaskFactoryBuilder.java
@@ -54,7 +54,7 @@ public class DepositIngestTaskFactoryBuilder {
         final var bagDataManager = new BagDataManagerImpl(bagReader);
         final var bagDirResolver = new BagDirResolverImpl(fileService);
         final var depositReader = new DepositReaderImpl(xmlReader, bagDirResolver, fileService, bagDataManager, depositFileLister, new ManifestHelperImpl());
-        final var depositLocationReader = new DepositLocationReaderImpl(bagDirResolver, bagDataManager);
+        final var depositLocationReader = new DepositLocationReaderImpl(bagDataManager);
         final var depositWriter = new DepositWriterImpl(bagDataManager);
 
         this.configuration = configuration;

--- a/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/DepositStartImportTaskWrapperTest.java
@@ -87,7 +87,7 @@ public class DepositStartImportTaskWrapperTest {
         var fileService = Mockito.mock(FileService.class);
         var bagDataManager = Mockito.mock(BagDataManager.class);
         var bagDirResolver = new BagDirResolverImpl(fileService);
-        var depositLocationReader = new DepositLocationReaderImpl(bagDirResolver, bagDataManager);
+        var depositLocationReader = new DepositLocationReaderImpl(bagDataManager);
         var manifestHelper = Mockito.mock(ManifestHelper.class);
         var depositReader = new DepositReaderImpl(xmlReader, bagDirResolver, fileService, bagDataManager, depositFileLister, manifestHelper);
         var depositWriter = new DepositWriterImpl(bagDataManager);

--- a/src/test/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImplTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/deposit/DepositLocationReaderImplTest.java
@@ -40,6 +40,7 @@ class DepositLocationReaderImplTest {
         var config = new BaseConfiguration();
         config.setProperty("dataverse.sword-token", "token");
         config.setProperty("identifier.doi", "doi");
+        config.setProperty("creation.timestamp", "2022-10-01T00:03:04+03:00");
 
         Mockito.doReturn(config)
             .when(bagDataManager).readDepositProperties(Mockito.any());


### PR DESCRIPTION
Fixes DD-1539

# Description of changes
Replaced `Created` from `bag-info.txt` with `creation.timestamp` from `deposit.properties` as the value on which to sort deposits on service start-up. `Created` from `bag-info.txt` is being phased out and will be ignored.


# Notify

@DANS-KNAW/core-systems
