### PR TITLE
DD-1459 Fix uncontrolled data used in path expression - Test 2A

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/AbstractIngestArea.java
@@ -80,4 +80,11 @@ public class AbstractIngestArea {
             throw new IllegalArgumentException("cannot initialize outbox for batch at " + outbox, e);
         }
     }
+
+    public void checkBaseFolderSecurity(Path path) throws RuntimeException {
+        Path toCheckPath = path.normalize().toAbsolutePath();
+        if (!toCheckPath.startsWith(this.inboxDir)) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
+        }
+    }
 }

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -46,6 +46,7 @@ public class ImportsResource {
     public Response startImport(StartImport start) {
         log.debug("Received command = {}", start);
         String batchName;
+        importArea.checkBaseFolderSecurity(start.getInputPath());
         try {
             batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
         }


### PR DESCRIPTION
Fixes DD-1459 Fix uncontrolled data used in path expression

# Description of changes
 `public Response startImport(StartImport start) {`
        ` log.debug("Received command = {}", start);`
        `String batchName;`
        `try {`
            `importArea.checkBaseFolderSecurity(start.getInputPath());`
            `batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());`
        `}`


# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
