### PR TITLE
DD-1459 Fix uncontrolled data used in path expression - Test 3A

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -83,6 +83,9 @@ public class ImportArea extends AbstractIngestArea {
         return relativeInputDir.toString();
     }
 
+    public Path getInboxDir() {
+        return inboxDir;
+    }
     private void validateBatchDirectory(Path input) {
         if (Files.isDirectory(input)) {
             try (Stream<Path> subPaths = Files.list(input)) {

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -45,6 +45,7 @@ public class ImportsResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response startImport(StartImport start) {
         log.debug("Received command = {}", start);
+        checkBaseFolderSecurity(start.getInputPath());
         String batchName;
         try {
             batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
@@ -56,5 +57,12 @@ public class ImportsResource {
                 new ResponseMessage(Response.Status.ACCEPTED.getStatusCode(),
                     String.format("import request was received (batch = %s, continue = %s", batchName, start.isContinue())))
             .build();
+    }
+
+    private void checkBaseFolderSecurity(java.nio.file.Path path) throws RuntimeException {
+        java.nio.file.Path toCheckPath = path.normalize().toAbsolutePath();
+        if (!toCheckPath.startsWith(importArea.getInboxDir())) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -45,6 +45,7 @@ public class MigrationsResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response startImport(StartImport start) {
         log.info("Received command = {}", start);
+        checkBaseFolderSecurity(start.getInputPath());
         String taskName;
         try {
             taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
@@ -56,6 +57,13 @@ public class MigrationsResource {
                 new ResponseMessage(Response.Status.ACCEPTED.getStatusCode(),
                     String.format("migration request was received (batch = %s, continue = %s", taskName, start.isContinue())))
             .build();
+    }
+
+    private void checkBaseFolderSecurity(java.nio.file.Path path) throws RuntimeException {
+        java.nio.file.Path toCheckPath = path.normalize().toAbsolutePath();
+        if (!toCheckPath.startsWith(migrationArea.getInboxDir())) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
+        }
     }
 
 }


### PR DESCRIPTION
Fixes DD-1459 Fix uncontrolled data used in path expression

# Description of changes
    ImortResource and MigrationsResource:

`    public Response startImport(StartImport start) {`
`        log.debug("Received command = {}", start);`
`        checkBaseFolderSecurity(start.getInputPath());`
`        String batchName;`
`        try {`
`            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());`
        }`

`    private void checkBaseFolderSecurity(java.nio.file.Path path) throws RuntimeException {`
`       java.nio.file.Path toCheckPath = path.normalize().toAbsolutePath();`
`        if (!toCheckPath.startsWith(importArea.getInboxDir())) {`
`            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));`
`        }`
`    }`
`


# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
