### PR TITLE
DD-1459 Fix Uncontrolled data used in path expression - Test 4A

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -108,4 +108,12 @@ public class ImportArea extends AbstractIngestArea {
             throw new IllegalArgumentException(String.format("Directory %s does not contain file deposit.properties. Not a valid deposit directory", input));
         }
     }
+
+    public Path getSecurePath(Path path) throws RuntimeException {
+        Path normalizedPath = path.normalize().toAbsolutePath();
+        if (!normalizedPath.startsWith(this.inboxDir)) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", normalizedPath));
+        }
+        return normalizedPath;
+    }
 }

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -47,7 +47,8 @@ public class ImportsResource {
         log.debug("Received command = {}", start);
         String batchName;
         try {
-            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
+            java.nio.file.Path securePath = importArea.getSecurePath(start.getInputPath());
+            batchName = importArea.startImport(securePath, start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -47,7 +47,8 @@ public class MigrationsResource {
         log.info("Received command = {}", start);
         String taskName;
         try {
-            taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
+            java.nio.file.Path securePath = migrationArea.getSecurePath(start.getInputPath());
+            taskName = migrationArea.startImport(securePath, start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());


### PR DESCRIPTION
Fixes DD-1459 Fix Uncontrolled data used in path expression

# Description of changes
  - Add `getSecurePath(Path path)` to `ImportArea.java`
  - Checking the trusted base folders of `dd-ingest-flow` in the classes`ImoprtResource` and `MigrationResource`

# How to test and follow it in debugger
  - Starting vagrant - open terminal and follow the instructions below :
    - `start-preprovisioned-box.py -s dev_archaeology`
    - `deploy.py  -m dd-ingest-flow dev_archaeology`
    - `vagrant ssh`
    - `cd /var/opt/dans.knaw.nl/tmp`
    - `tree -L 5` (to oversee the working folders and deposits)
    -  Create to test folders inside import and migration folders
      - `mkdir import/deposits/test-folder`
      - `mkdir migration/deposits/test-folder`
    - copy one of the deposits into new created test-folders
      - `cp -r auto-ingest/outbox/processed/33afaff6-e08a-4bfa-9960-2b48b616d2c9/ import/inbox/test-folder/` 
      - `cp -r auto-ingest/outbox/processed/33afaff6-e08a-4bfa-9960-2b48b616d2c9/ migration/deposits/test-folder/`
    - open dd-ingest-flow porject in IntelliJ and run remote-debug with info:
      - remote debug
      - host: dev.sword2.archaeology.datastations.nl
      - port: 20302 
    - Commands to import or migrate deposits:
      - `ingest-flow start-import -s import/inbox/test-folder/33afaff6-e08a-4bfa-9960-2b48b616d2c9/`
      - `ingest-flow start-migration -s migration/deposits/test-folder/33afaff6-e08a-4bfa-9960-2b48b616d2c9/` 

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
