### PR TITLE
Dd 1459 fix uncontrolled data used in paths Test 5A

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -109,11 +109,11 @@ public class ImportArea extends AbstractIngestArea {
         }
     }
 
-    public Path getSecurePath(Path path) throws RuntimeException {
-        Path normalizedPath = path.normalize().toAbsolutePath();
-        if (!normalizedPath.startsWith(this.inboxDir)) {
-            throw new IllegalArgumentException(String.format("InsecurePath %s", normalizedPath));
+    public void checkBaseFolderSecurity(Path path) throws RuntimeException {
+        Path toCheckPath = path.normalize().toAbsolutePath();
+        if (!toCheckPath.startsWith(this.inboxDir)) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));
         }
-        return normalizedPath;
     }
+
 }

--- a/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/ImportArea.java
@@ -108,4 +108,12 @@ public class ImportArea extends AbstractIngestArea {
             throw new IllegalArgumentException(String.format("Directory %s does not contain file deposit.properties. Not a valid deposit directory", input));
         }
     }
+
+    public Path getSecurePath(Path path) throws RuntimeException {
+        Path normalizedPath = path.normalize().toAbsolutePath();
+        if (!normalizedPath.startsWith(this.inboxDir)) {
+            throw new IllegalArgumentException(String.format("InsecurePath %s", normalizedPath));
+        }
+        return normalizedPath;
+    }
 }

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -47,7 +47,8 @@ public class ImportsResource {
         log.debug("Received command = {}", start);
         String batchName;
         try {
-            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
+            java.nio.file.Path securePath = importArea.getSecurePath(start.getInputPath());
+            batchName = importArea.startImport(securePath, start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/ImportsResource.java
@@ -47,8 +47,8 @@ public class ImportsResource {
         log.debug("Received command = {}", start);
         String batchName;
         try {
-            java.nio.file.Path securePath = importArea.getSecurePath(start.getInputPath());
-            batchName = importArea.startImport(securePath, start.isBatch(), start.isContinue());
+            importArea.checkBaseFolderSecurity(start.getInputPath());
+            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -47,7 +47,8 @@ public class MigrationsResource {
         log.info("Received command = {}", start);
         String taskName;
         try {
-            taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
+            java.nio.file.Path securePath = migrationArea.getSecurePath(start.getInputPath());
+            taskName = migrationArea.startImport(securePath, start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());

--- a/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
+++ b/src/main/java/nl/knaw/dans/ingest/resources/MigrationsResource.java
@@ -47,8 +47,8 @@ public class MigrationsResource {
         log.info("Received command = {}", start);
         String taskName;
         try {
-            java.nio.file.Path securePath = migrationArea.getSecurePath(start.getInputPath());
-            taskName = migrationArea.startImport(securePath, start.isBatch(), start.isContinue());
+            migrationArea.checkBaseFolderSecurity(start.getInputPath());
+            taskName = migrationArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());
         }
         catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());


### PR DESCRIPTION
Fixes DD-1459 fix uncontrolled data used in path expresion

# Description of changes
  - ImportArea.java
 
`public void checkBaseFolderSecurity(Path path) throws RuntimeException {`
`    Path toCheckPath = path.normalize().toAbsolutePath();`
`     if (!toCheckPath.startsWith(this.inboxDir)) {`
`        throw new IllegalArgumentException(String.format("InsecurePath %s", toCheckPath));`
`    }`
`}`


  - Import/MigrationResource
`      public Response startImport(StartImport start) {`
`        log.debug("Received command = {}", start);`
`        String batchName;`
`        try {`
`            importArea.checkBaseFolderSecurity(start.getInputPath())`
`            batchName = importArea.startImport(start.getInputPath(), start.isBatch(), start.isContinue());`
`        }`

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
