### PR TITLE
NO JIRA. Add missing draft deletion action

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
@@ -90,7 +90,7 @@ public class DatasetCreator extends DatasetEditor {
             catch (IOException | DataverseException ex) {
                 log.error("Error deleting draft dataset", ex);
             }
-            throw new FailedDepositException(deposit, "Error creating dataset, deleting draft", e);
+            throw new FailedDepositException(deposit, "Error creating dataset" + (this.deleteDraftOnFailure ? ". Deleting draft" : "."), e);
         }
     }
 

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetCreator.java
@@ -73,14 +73,23 @@ public class DatasetCreator extends DatasetEditor {
         var api = dataverseClient.dataverse("root");
 
         log.debug("Creating new dataset");
+        String persistentId = null;
 
         try {
-            var persistentId = importDataset(api);
+            persistentId = importDataset(api);
             log.debug("New persistent ID: {}", persistentId);
             modifyDataset(persistentId);
             return persistentId;
         }
         catch (Exception e) {
+            try {
+                if (persistentId != null) {
+                    deleteDraftIfExists(persistentId);
+                }
+            }
+            catch (IOException | DataverseException ex) {
+                log.error("Error deleting draft dataset", ex);
+            }
             throw new FailedDepositException(deposit, "Error creating dataset, deleting draft", e);
         }
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetEditor.java
@@ -74,7 +74,7 @@ public abstract class DatasetEditor {
 
     protected final String vaultMetadataKey;
 
-    private boolean deleteDraftOnFailure;
+    protected boolean deleteDraftOnFailure;
 
     protected DatasetEditor(boolean isMigration,
         Dataset dataset,

--- a/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/DatasetUpdater.java
@@ -231,7 +231,7 @@ public class DatasetUpdater extends DatasetEditor {
                 return doi;
             }
             catch (Exception e) {
-                log.error("Error updating dataset, deleting draft", e);
+                log.error("Error updating dataset" + (deleteDraftOnFailure ? ", deleting draft" : ""), e);
                 deleteDraftIfExists(doi);
                 throw e;
             }
@@ -242,7 +242,7 @@ public class DatasetUpdater extends DatasetEditor {
         }
         finally {
             if (originalMetadata != null) {
-                FileUtils.deleteQuietly(originalMetadata.getPath().toFile())    ;
+                FileUtils.deleteQuietly(originalMetadata.getPath().toFile());
             }
         }
     }


### PR DESCRIPTION
# Description of changes
When an ingest fails, any draft dataset version that was created is deleted if the setting `deleteOfFailure` is set to true. This was not correctly implemented yet for new datasets (only for updates).


# Notify

@DANS-KNAW/core-systems
