### PR TITLE
Use dd-parent 1.5.0 with updated client lib for dataverse 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.3.1</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>dd-ingest-flow</artifactId>


### PR DESCRIPTION
Fixes DD-1565

# Description of changes
Use dd-parent 1.5.0 with updated client lib for dataverse 6.2

# How to test

# Related PRs

(Add links)

*https://github.com/DANS-KNAW/dd-validate-dans-bag/pull/54
*https://github.com/DANS-KNAW/dd-vault-metadata/pull/13

# Notify

@DANS-KNAW/core-systems
