### PR TITLE
DD-1566: fix multiplicity alternative title

### DIFF
--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -143,7 +143,6 @@ public class DepositToDvDatasetMetadataMapper {
             citationFields.addDescription(getProfileDescriptions(ddm), Description.toDescription); // CIT009
 
             // CIT010
-            // TODO when multiple alternative titles is used, adding to the description is not needed anymore
             if (otherTitlesAndAlternativeTitles.size() > 1) { // First element is put in alternativeTitle field. See CIT002
                 citationFields.addDescription(otherTitlesAndAlternativeTitles.stream().skip(1), Description.toDescription);
             }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/DepositToDvDatasetMetadataMapper.java
@@ -143,6 +143,7 @@ public class DepositToDvDatasetMetadataMapper {
             citationFields.addDescription(getProfileDescriptions(ddm), Description.toDescription); // CIT009
 
             // CIT010
+            // TODO when multiple alternative titles is used, adding to the description is not needed anymore
             if (otherTitlesAndAlternativeTitles.size() > 1) { // First element is put in alternativeTitle field. See CIT002
                 citationFields.addDescription(otherTitlesAndAlternativeTitles.stream().skip(1), Description.toDescription);
             }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
@@ -68,7 +68,6 @@ public class CitationFieldBuilder extends FieldBuilder {
 
     public void addAlternativeTitle(Stream<String> stream) {
         // Use only the first value (like it is a single value), but then process as a multiple
-        // TODO pass all values instead of only the first one
         Stream<String> firstElementStream = Stream.of(stream.findFirst().orElse(null));
         addMultiplePrimitiveString(ALTERNATIVE_TITLE, firstElementStream);
     }

--- a/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
+++ b/src/main/java/nl/knaw/dans/ingest/core/service/mapper/builder/CitationFieldBuilder.java
@@ -67,7 +67,10 @@ public class CitationFieldBuilder extends FieldBuilder {
     }
 
     public void addAlternativeTitle(Stream<String> stream) {
-        addSingleString(ALTERNATIVE_TITLE, stream);
+        // Use only the first value (like it is a single value), but then process as a multiple
+        // TODO pass all values instead of only the first one
+        Stream<String> firstElementStream = Stream.of(stream.findFirst().orElse(null));
+        addMultiplePrimitiveString(ALTERNATIVE_TITLE, firstElementStream);
     }
 
     public void addDescription(Stream<Node> stream, CompoundFieldGenerator<Node> generator) {

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromDcmiTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromDcmiTest.java
@@ -93,9 +93,12 @@ public class CitationMetadataFromDcmiTest {
         var result = mapDdmToDataset(doc, true);
 
         // CIT002 first of dcmi title/alternative
-        assertThat(getPrimitiveSingleValueField("citation", ALTERNATIVE_TITLE, result))
-            .isEqualTo("title 1");
-
+        //assertThat(getPrimitiveSingleValueField("citation", ALTERNATIVE_TITLE, result))
+        //    .isEqualTo("title 1");
+        assertThat(getPrimitiveMultiValueField("citation", ALTERNATIVE_TITLE, result))
+                .containsExactly("title 1");
+        
+        
         // CIT010 rest of dcmi title/alternative
         assertThat(getCompoundMultiValueField("citation", DESCRIPTION, result))
             .extracting(DESCRIPTION_VALUE).extracting("value")

--- a/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromDcmiTest.java
+++ b/src/test/java/nl/knaw/dans/ingest/core/service/mapper/CitationMetadataFromDcmiTest.java
@@ -93,8 +93,6 @@ public class CitationMetadataFromDcmiTest {
         var result = mapDdmToDataset(doc, true);
 
         // CIT002 first of dcmi title/alternative
-        //assertThat(getPrimitiveSingleValueField("citation", ALTERNATIVE_TITLE, result))
-        //    .isEqualTo("title 1");
         assertThat(getPrimitiveMultiValueField("citation", ALTERNATIVE_TITLE, result))
                 .containsExactly("title 1");
         


### PR DESCRIPTION
Fixes DD-1566

# Description of changes

# How to test

Start the archaeology dev box
```
start-preprovisioned-box.py -s        
```
Then deploy the upgrade to 6.2
```
deploy.py --playbook provisioning/patches/upgrade-dataverse/to-6.2.yml dev_archaeology

```
For now upgrade these modules because that is not part of the `to-6.2` yet
```
deploy.py -t dd-vault-metadata dev_archaeology
deploy.py -t dd-validate-dans-bag dev_archaeology
deploy.py -t dd-ingest-flow dev_archaeology
```
Go to the sword2 examples:
`~/git/dans-core-systems/modules/dd-dans-sword2-examples` and run the one we know that fails: 
```
./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/all-mappings
```
That should fail, we have not updated the ingest flow with our PR!

Next us update the dev box with our PR (dd-ingest-flow). Check it out, build it and then deploy.
```
deploy.py -m dd-ingest-flow dev_archaeology
```
Run the depost again, now it should succes (published dataset). 

You can run all the other valid depostis
```
./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/default-open

./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/default-restricted

./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/embargoed

./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/audiences

./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001  src/main/resources/example-bags/valid/audiences-sha256

# Sequences

# valid/revision
./run-sequence-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/revision01 src/main/resources/example-bags/valid/revision02 src/main/resources/example-bags/valid/revision03

# valid/movements
./run-sequence-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/movements01 src/main/resources/example-bags/valid/movements02
```

Below a screendump of a successful deposted 'all-mappings' dataset citation metadata. 
![Screenshot from 2024-05-29 10-36-45](https://github.com/DANS-KNAW/dd-ingest-flow/assets/2151103/0b9c0753-2a81-4940-bdbc-188c15bca301)



# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
